### PR TITLE
Fix Pages deploy auth + bring in Gemini switch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,4 +41,3 @@ jobs:
         uses: JamesIves/github-pages-deploy-action@v4
         with:
           folder: frontend/dist
-          token: ${{ secrets.TOKEN }}

--- a/README.md
+++ b/README.md
@@ -120,4 +120,5 @@ docker run -p 8000:8000 --env-file .env vsezol-agent
 
 Pushing to `master` triggers `.github/workflows/deploy.yml`: it builds
 `frontend/` (with `VITE_API_URL` from the `API_URL` repo variable) and pushes
-`frontend/dist` to the `gh-pages` branch via the `TOKEN` secret.
+`frontend/dist` to the `gh-pages` branch using the workflow's built-in
+`GITHUB_TOKEN` (no personal token needed).

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Google Calendar with a Google Meet link, and emails invitations to both sides.
 frontend/   React + Vite + Mantine + @chatscope/chat-ui-kit-react
             → GitHub Pages (this repo, gh-pages branch)
 
-backend/    Python + FastAPI + Pydantic AI (Claude via API key)
+backend/    Python + FastAPI + Pydantic AI (Gemini by default, any provider via LLM_MODEL)
             + Google Calendar API (Meet link, invites, freebusy check)
             → any Docker host (Fly.io / Railway / Render / VPS)
 ```
@@ -50,8 +50,8 @@ Run tests: `uv run pytest`.
 
 | Variable | Purpose |
 | --- | --- |
-| `ANTHROPIC_API_KEY` | Claude API key (required) |
-| `ANTHROPIC_MODEL` | default `claude-opus-4-8`; use `claude-sonnet-4-6` to cut costs |
+| `GEMINI_API_KEY` | Gemini API key (required with the default model) |
+| `LLM_MODEL` | any pydantic-ai model string; default `google:gemini-3.5-flash`, e.g. `anthropic:claude-opus-4-8` (then set `ANTHROPIC_API_KEY`) |
 | `OWNER_NAME` / `OWNER_EMAIL` / `OWNER_TIMEZONE` | whose calendar to book |
 | `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` / `GOOGLE_REFRESH_TOKEN` | Google Calendar access |
 | `DEMO_MODE` | `true` → fake bookings, no Google calls (local dev only) |
@@ -89,7 +89,7 @@ and the Dockerfile respects Railway's `PORT`.
 3. **Variables → Raw Editor** → paste and fill in:
 
    ```env
-   ANTHROPIC_API_KEY=sk-ant-...
+   GEMINI_API_KEY=...
    GOOGLE_CLIENT_ID=...apps.googleusercontent.com
    GOOGLE_CLIENT_SECRET=...
    GOOGLE_REFRESH_TOKEN=...

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,7 +1,8 @@
 # --- LLM ---
-ANTHROPIC_API_KEY=sk-ant-...
-# Optional: switch model (e.g. claude-sonnet-4-6 to cut costs)
-# ANTHROPIC_MODEL=claude-opus-4-8
+GEMINI_API_KEY=...
+# Optional: any pydantic-ai "provider:model" string
+# LLM_MODEL=google:gemini-3.5-flash
+# Anthropic instead: LLM_MODEL=anthropic:claude-opus-4-8 + ANTHROPIC_API_KEY=sk-ant-...
 
 # --- Owner ---
 OWNER_NAME=Vsevolod Zolotov

--- a/backend/app/agent.py
+++ b/backend/app/agent.py
@@ -99,7 +99,7 @@ Rules:
 """
 
 agent = Agent(
-    f"anthropic:{settings.anthropic_model}",
+    settings.llm_model,
     deps_type=AgentDeps,
     output_type=[str, AskEmail, AskDateTime],
     retries=2,

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -6,8 +6,9 @@ class Settings(BaseSettings):
         env_file=".env", env_file_encoding="utf-8", extra="ignore"
     )
 
-    # LLM (ANTHROPIC_API_KEY is read from the environment by pydantic-ai)
-    anthropic_model: str = "claude-opus-4-8"
+    # LLM: any pydantic-ai "provider:model" string. Gemini needs
+    # GEMINI_API_KEY in the environment, Anthropic needs ANTHROPIC_API_KEY.
+    llm_model: str = "google:gemini-3.5-flash"
 
     # Owner
     owner_name: str = "Vsevolod Zolotov"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -6,7 +6,7 @@ requires-python = ">=3.12"
 dependencies = [
     "fastapi>=0.115",
     "uvicorn[standard]>=0.32",
-    "pydantic-ai-slim[anthropic]>=1.0,<2.0",
+    "pydantic-ai-slim[google,anthropic]>=1.0,<2.0",
     "pydantic-settings>=2.6",
     "google-api-python-client>=2.150",
     "google-auth>=2.35",

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -1,7 +1,7 @@
 import os
 
 os.environ["DEMO_MODE"] = "true"
-os.environ.setdefault("ANTHROPIC_API_KEY", "test-key")
+os.environ.setdefault("GEMINI_API_KEY", "test-key")
 
 from datetime import datetime, timedelta, timezone
 

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -358,6 +358,11 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/e8/1d/f6d3ca1ad0725f2e08a1c6915640748a52de2e66596160a4d53b010cccf0/google_auth-2.55.1-py3-none-any.whl", hash = "sha256:eada68dfd52b3b81191827601e2a0c3fa12540c818534b630ddc5355769c3995", size = 252349, upload-time = "2026-06-25T23:38:52.946Z" },
 ]
 
+[package.optional-dependencies]
+requests = [
+    { name = "requests" },
+]
+
 [[package]]
 name = "google-auth-httplib2"
 version = "0.4.0"
@@ -382,6 +387,27 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/70/18/90c7fac516e63cf2058166fce0c88c353647c677b51cc036c09c49bb5cbb/google_auth_oauthlib-1.4.0.tar.gz", hash = "sha256:18b5e28880eb8eba9065c436becdc0ee8e4b59117a73a510679c82f70cd363d2", size = 21675, upload-time = "2026-05-07T08:03:47.816Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/37/d3/d7dff0d58a9e9244b48044bfb6a898bfcc8ecc42e0031d1bebc695344725/google_auth_oauthlib-1.4.0-py3-none-any.whl", hash = "sha256:251314f213a9ee46a5ae73988e84fd7cca8bb68e7ecf4bfd45940f9e7f51d070", size = 19261, upload-time = "2026-05-07T08:02:13.798Z" },
+]
+
+[[package]]
+name = "google-genai"
+version = "2.10.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "google-auth", extra = ["requests"] },
+    { name = "httpx" },
+    { name = "pydantic" },
+    { name = "requests" },
+    { name = "sniffio" },
+    { name = "tenacity" },
+    { name = "typing-extensions" },
+    { name = "websockets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cd/fe/b796087493c3c55371aa58b9f264841ace5bfdf8c668cafa7afa33c44bec/google_genai-2.10.0.tar.gz", hash = "sha256:77912cd558cd7dfd5b75c25fd1c609e78d7954dde583331104022a46ea90f9ee", size = 600039, upload-time = "2026-06-24T01:33:18.157Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/39/00bcfd94de255d24249401efff4f48d77bf6066b46447e519fa193c0c299/google_genai-2.10.0-py3-none-any.whl", hash = "sha256:d5350311567ae660c24cbc1752aee4b3d660f89c0106d2dcd2a69978c35afe1e", size = 957974, upload-time = "2026-06-24T01:33:16.296Z" },
 ]
 
 [[package]]
@@ -747,6 +773,9 @@ wheels = [
 anthropic = [
     { name = "anthropic" },
 ]
+google = [
+    { name = "google-genai" },
+]
 
 [[package]]
 name = "pydantic-core"
@@ -992,6 +1021,15 @@ wheels = [
 ]
 
 [[package]]
+name = "tenacity"
+version = "9.1.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/c6/ee486fd809e357697ee8a44d3d69222b344920433d3b6666ccd9b374630c/tenacity-9.1.4.tar.gz", hash = "sha256:adb31d4c263f2bd041081ab33b498309a57c77f9acf2db65aadf0898179cf93a", size = 49413, upload-time = "2026-02-07T10:45:33.841Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl", hash = "sha256:6095a360c919085f28c6527de529e76a06ad89b23659fa881ae0649b867a9d55", size = 28926, upload-time = "2026-02-07T10:45:32.24Z" },
+]
+
+[[package]]
 name = "truststore"
 version = "0.10.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1104,7 +1142,7 @@ dependencies = [
     { name = "google-api-python-client" },
     { name = "google-auth" },
     { name = "google-auth-oauthlib" },
-    { name = "pydantic-ai-slim", extra = ["anthropic"] },
+    { name = "pydantic-ai-slim", extra = ["anthropic", "google"] },
     { name = "pydantic-settings" },
     { name = "uvicorn", extra = ["standard"] },
 ]
@@ -1121,7 +1159,7 @@ requires-dist = [
     { name = "google-api-python-client", specifier = ">=2.150" },
     { name = "google-auth", specifier = ">=2.35" },
     { name = "google-auth-oauthlib", specifier = ">=1.2" },
-    { name = "pydantic-ai-slim", extras = ["anthropic"], specifier = ">=1.0,<2.0" },
+    { name = "pydantic-ai-slim", extras = ["google", "anthropic"], specifier = ">=1.0,<2.0" },
     { name = "pydantic-settings", specifier = ">=2.6" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.32" },
 ]


### PR DESCRIPTION
Two things:

1. **Deploy fix**: the `TOKEN` secret is expired — the gh-pages push failed with "Invalid username or token". The workflow already has `contents: write`, and the deploy action falls back to the built-in `GITHUB_TOKEN` when no token is passed, so the secret is dropped entirely.
2. **Cherry-pick of the Gemini switch** (`LLM_MODEL=google:gemini-3.5-flash` by default, provider-agnostic via pydantic-ai) — it was pushed to the PR #4 branch right after the PR got merged, so master never received it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)