### PR TITLE
Allow vsezol.com in default CORS origins

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -18,4 +18,4 @@ GOOGLE_REFRESH_TOKEN=...
 # DEMO_MODE=true
 
 # --- CORS ---
-CORS_ORIGINS=https://vsezol.github.io,http://localhost:5173
+CORS_ORIGINS=https://vsezol.com,https://www.vsezol.com,https://vsezol.github.io,http://localhost:5173

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -24,7 +24,10 @@ class Settings(BaseSettings):
     # Local development only — never enable in production.
     demo_mode: bool = False
 
-    cors_origins: str = "https://vsezol.github.io,http://localhost:5173"
+    cors_origins: str = (
+        "https://vsezol.com,https://www.vsezol.com,"
+        "https://vsezol.github.io,http://localhost:5173"
+    )
 
     rate_limit_requests: int = 30
     rate_limit_window_seconds: int = 300


### PR DESCRIPTION
The site is served on the custom domain `vsezol.com` (Pages 301-redirects `vsezol.github.io` there), so the browser's requests to the Railway backend originate from `https://vsezol.com`. Added it (plus `www`) to the default `CORS_ORIGINS`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)