### PR TITLE
Fallback LLM when the primary model errors

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,6 +1,7 @@
 # --- LLM ---
 GEMINI_API_KEY=...
 # Optional: any pydantic-ai "provider:model" string
+# LLM_FALLBACK_MODEL=google:gemini-2.5-flash  # used when the primary errors
 # LLM_MODEL=google:gemini-3.5-flash
 # Anthropic instead: LLM_MODEL=anthropic:claude-opus-4-8 + ANTHROPIC_API_KEY=sk-ant-...
 

--- a/backend/app/agent.py
+++ b/backend/app/agent.py
@@ -6,6 +6,7 @@ from zoneinfo import ZoneInfo
 
 from pydantic import BaseModel, Field
 from pydantic_ai import Agent, ModelRetry, RunContext
+from pydantic_ai.models.fallback import FallbackModel
 
 from .calendar_service import BookingResult, create_meeting, is_slot_free
 from .config import settings
@@ -116,8 +117,14 @@ Rules:
   invent facts about {settings.owner_name}.
 """
 
+_model = (
+    FallbackModel(settings.llm_model, settings.llm_fallback_model)
+    if settings.llm_fallback_model
+    else settings.llm_model
+)
+
 agent = Agent(
-    settings.llm_model,
+    _model,
     deps_type=AgentDeps,
     output_type=[str, AskEmail, AskDateTime, AskConfirm],
     retries=2,

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -9,6 +9,9 @@ class Settings(BaseSettings):
     # LLM: any pydantic-ai "provider:model" string. Gemini needs
     # GEMINI_API_KEY in the environment, Anthropic needs ANTHROPIC_API_KEY.
     llm_model: str = "google:gemini-3.5-flash"
+    # Used automatically when the primary model errors (e.g. 503 overload).
+    # Set empty to disable.
+    llm_fallback_model: str = "google:gemini-2.5-flash"
 
     # Owner
     owner_name: str = "Vsevolod Zolotov"


### PR DESCRIPTION
Production hit `503 UNAVAILABLE — model experiencing high demand` on `gemini-3.5-flash`. The agent's model is now a pydantic-ai `FallbackModel`: when the primary errors, the request transparently retries on `LLM_FALLBACK_MODEL` (default `google:gemini-2.5-flash`; set empty to disable). Tests 5/5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)