### PR TITLE
Fast non-thinking model + resilient availability check

### DIFF
--- a/backend/app/agent.py
+++ b/backend/app/agent.py
@@ -7,6 +7,7 @@ from zoneinfo import ZoneInfo
 from pydantic import BaseModel, Field
 from pydantic_ai import Agent, ModelRetry, RunContext
 from pydantic_ai.models.fallback import FallbackModel
+from pydantic_ai.models.google import GoogleModelSettings
 
 from .calendar_service import BookingResult, create_meeting, is_slot_free
 from .config import settings
@@ -129,6 +130,11 @@ agent = Agent(
     output_type=[str, AskEmail, AskDateTime, AskConfirm],
     retries=2,
     instructions=SYSTEM_PROMPT,
+    # Latency matters more than deep reasoning here; Gemini flash models
+    # think by default — turn it off. Ignored by non-Google models.
+    model_settings=GoogleModelSettings(
+        google_thinking_config={"thinking_budget": 0}
+    ),
 )
 
 

--- a/backend/app/calendar_service.py
+++ b/backend/app/calendar_service.py
@@ -6,12 +6,12 @@ from datetime import datetime, timedelta
 from google.auth.transport.requests import Request
 from google.oauth2.credentials import Credentials
 from googleapiclient.discovery import build
+from googleapiclient.errors import HttpError
 
 from .config import settings
 
 logger = logging.getLogger(__name__)
 
-SCOPES = ["https://www.googleapis.com/auth/calendar.events"]
 TOKEN_URI = "https://oauth2.googleapis.com/token"
 
 
@@ -25,13 +25,14 @@ class BookingResult:
 
 
 def _calendar_service():
+    # scopes intentionally omitted: the refresh grant keeps whatever scopes
+    # the user consented to (see scripts/get_google_refresh_token.py)
     creds = Credentials(
         token=None,
         refresh_token=settings.google_refresh_token,
         token_uri=TOKEN_URI,
         client_id=settings.google_client_id,
         client_secret=settings.google_client_secret,
-        scopes=SCOPES,
     )
     creds.refresh(Request())
     return build("calendar", "v3", credentials=creds, cache_discovery=False)
@@ -52,17 +53,23 @@ def is_slot_free(start: datetime, duration_minutes: int) -> bool:
     if settings.owner_email:
         ids.append(settings.owner_email)
     service = _calendar_service()
-    response = (
-        service.freebusy()
-        .query(
-            body={
-                "timeMin": start.isoformat(),
-                "timeMax": end.isoformat(),
-                "items": [{"id": i} for i in ids],
-            }
+    try:
+        response = (
+            service.freebusy()
+            .query(
+                body={
+                    "timeMin": start.isoformat(),
+                    "timeMax": end.isoformat(),
+                    "items": [{"id": i} for i in ids],
+                }
+            )
+            .execute()
         )
-        .execute()
-    )
+    except HttpError as exc:
+        # Availability check must never block a booking (e.g. the refresh
+        # token was granted without the freebusy scope).
+        logger.warning("FreeBusy check failed, assuming the slot is free: %s", exc)
+        return True
     for calendar in response.get("calendars", {}).values():
         if calendar.get("errors"):
             continue  # not shared with the bot — can't see it, skip

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -8,10 +8,12 @@ class Settings(BaseSettings):
 
     # LLM: any pydantic-ai "provider:model" string. Gemini needs
     # GEMINI_API_KEY in the environment, Anthropic needs ANTHROPIC_API_KEY.
-    llm_model: str = "google:gemini-3.5-flash"
+    # gemini-2.5-flash with thinking disabled: fast enough for a chat UI.
+    # (gemini-3.5-flash is a thinking model — noticeably slower + overloaded.)
+    llm_model: str = "google:gemini-2.5-flash"
     # Used automatically when the primary model errors (e.g. 503 overload).
     # Set empty to disable.
-    llm_fallback_model: str = "google:gemini-2.5-flash"
+    llm_fallback_model: str = "google:gemini-2.5-flash-lite"
 
     # Owner
     owner_name: str = "Vsevolod Zolotov"

--- a/backend/scripts/get_google_refresh_token.py
+++ b/backend/scripts/get_google_refresh_token.py
@@ -17,7 +17,11 @@ import sys
 
 from google_auth_oauthlib.flow import InstalledAppFlow
 
-SCOPES = ["https://www.googleapis.com/auth/calendar.events"]
+SCOPES = [
+    "https://www.googleapis.com/auth/calendar.events",
+    # availability check (FreeBusy API)
+    "https://www.googleapis.com/auth/calendar.freebusy",
+]
 
 
 def main() -> None:


### PR DESCRIPTION
Two production findings from the first real booking attempt:

1. **Booking failed at the final step**: `403 insufficient authentication scopes` on FreeBusy — the `calendar.events` scope doesn't cover it. The availability check now **fails open** (logs a warning, allows the booking), the token script requests `calendar.events + calendar.freebusy`, and the backend no longer pins scopes on refresh.
2. **Latency**: `gemini-3.5-flash` is a thinking model (slow) and keeps returning 503s. Default is now `gemini-2.5-flash` with `thinking_budget: 0` and `gemini-2.5-flash-lite` as fallback — responses should drop to ~1–3s.

Tests 5/5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)