### PR TITLE
Redirect vsezol.com/admin to the backend admin panel

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,6 +36,12 @@ jobs:
         env:
           VITE_API_URL: ${{ vars.API_URL }}
 
+      # The admin app is served by the backend (behind Basic Auth) — it has
+      # no business on the public Pages site. /admin redirects there instead
+      # (frontend/public/admin/index.html).
+      - name: Strip admin bundle from the public site
+        run: rm -f frontend/dist/admin.html
+
       - name: Deploy to GitHub Pages
         if: github.event_name != 'pull_request'
         uses: JamesIves/github-pages-deploy-action@v4

--- a/frontend/public/admin/index.html
+++ b/frontend/public/admin/index.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="color-scheme" content="dark" />
+    <meta name="robots" content="noindex" />
+    <meta http-equiv="refresh" content="0; url=https://vsezol-agent-api.up.railway.app/admin" />
+    <title>Agent Admin</title>
+    <style>
+      html,
+      body {
+        margin: 0;
+        height: 100%;
+        background: #0c0f14;
+        color: #8b94a6;
+        font: 500 14px 'Space Grotesk', sans-serif;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+      a {
+        color: #6e9bff;
+      }
+    </style>
+  </head>
+  <body>
+    <div>
+      Redirecting to the admin panel…
+      <a href="https://vsezol-agent-api.up.railway.app/admin">Open manually</a>
+    </div>
+    <script>
+      window.location.replace('https://vsezol-agent-api.up.railway.app/admin');
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
Opening `vsezol.com/admin` served the admin app shell from GitHub Pages, where `/admin/api/config` doesn't exist (404) and Basic Auth can't happen. Now:

- the Pages build strips `admin.html` from the public artifact
- `vsezol.com/admin` serves a redirect page → `https://vsezol-agent-api.up.railway.app/admin` (the auth-gated React admin)

🤖 Generated with [Claude Code](https://claude.com/claude-code)