### PR TITLE
feat: ru/en locale support + admin language tabs

### DIFF
--- a/backend/app/admin_config.py
+++ b/backend/app/admin_config.py
@@ -20,6 +20,11 @@ DEFAULT_GREETING = (
     "and book a meeting with me."
 )
 
+DEFAULT_GREETING_RU = (
+    "Это мой AI-агент — он может рассказать обо мне\n"
+    "и записать вас на встречу со мной."
+)
+
 DEFAULT_BIO = (
     "Vsevolod Zolotov is a Senior AI Engineer who builds LLM-powered "
     "products and agents."
@@ -28,6 +33,8 @@ DEFAULT_BIO = (
 
 class ButtonCfg(BaseModel):
     label: str = Field(max_length=40)
+    # Russian label; empty string means "same as `label`"
+    label_ru: str = Field(default="", max_length=40)
     kind: Literal["link", "about"] = "link"
     url: str = Field(default="", max_length=300)
 
@@ -47,7 +54,7 @@ class DayCfg(BaseModel):
 
 def _default_buttons() -> list[ButtonCfg]:
     return [
-        ButtonCfg(label="About Vsevolod", kind="about"),
+        ButtonCfg(label="About Vsevolod", label_ru="О Всеволоде", kind="about"),
         ButtonCfg(label="GitHub ↗", kind="link", url="https://github.com/vsezol"),
         ButtonCfg(
             label="LinkedIn ↗", kind="link", url="https://www.linkedin.com/in/vsezol"
@@ -67,9 +74,15 @@ class AgentConfig(BaseModel):
     subtitle: str = Field(
         default="Senior AI Engineer at OTP Group", max_length=100
     )
+    # Russian variants shown when the browser locale is Russian
+    title_ru: str = Field(default="Привет, я Всеволод", max_length=60)
+    subtitle_ru: str = Field(
+        default="Senior AI Engineer в OTP Group", max_length=100
+    )
     # Data URL (small JPEG) or None for the built-in photo
     avatar: str | None = Field(default=None, max_length=300_000)
     greeting: str = Field(default=DEFAULT_GREETING, max_length=1000)
+    greeting_ru: str = Field(default=DEFAULT_GREETING_RU, max_length=1000)
     bio: str = Field(default=DEFAULT_BIO, max_length=8000)
     buttons: list[ButtonCfg] = Field(default_factory=_default_buttons, max_length=8)
     schedule: list[DayCfg] = Field(default_factory=_default_schedule)

--- a/backend/app/agent.py
+++ b/backend/app/agent.py
@@ -105,6 +105,8 @@ class AskConfirm(BaseModel):
 @dataclass
 class AgentDeps:
     client_timezone: str
+    # "ru" when the visitor's browser locale is Russian, otherwise "en"
+    locale: str = "en"
     booking: BookingResult | None = None
     # How many times the output validator already asked the model to replace
     # a plain-text data request with a widget in this run.
@@ -143,14 +145,17 @@ def system_instructions(ctx: RunContext[AgentDeps]) -> str:
     tz = ZoneInfo(ctx.deps.client_timezone)
     now = datetime.now(tz)
     bio = cfg.bio.strip() or "He is a Senior AI Engineer."
+    start_language = "Russian" if ctx.deps.locale == "ru" else "English"
     return f"""\
 You are the personal AI agent of {settings.owner_name} on his personal site.
 Your job: chat with visitors and book meetings with him.
 
-LANGUAGE: always reply in the visitor's language — mirror the language of
-their most recent message (Russian → Russian, English → English, and so on).
-Messages starting with "[widget]" are system events, not language cues —
-keep using the visitor's last language.
+LANGUAGE: the visitor's browser locale is "{ctx.deps.locale}" — start the
+conversation in {start_language} and stay in it until the visitor writes in
+a different language; from then on mirror the language of their most recent
+message (Russian → Russian, English → English, and so on). Messages starting
+with "[widget]" are system events, not language cues — they never change
+the language.
 
 About {settings.owner_name} — your ONLY source of facts about him:
 {bio}

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -87,8 +87,11 @@ def public_config() -> dict:
     return {
         "title": cfg.title,
         "subtitle": cfg.subtitle,
+        "title_ru": cfg.title_ru,
+        "subtitle_ru": cfg.subtitle_ru,
         "avatar": cfg.avatar,
         "greeting": cfg.greeting,
+        "greeting_ru": cfg.greeting_ru,
         "buttons": [b.model_dump() for b in cfg.buttons],
         "schedule": [d.model_dump() for d in cfg.schedule],
         "slot_minutes": cfg.slot_minutes,
@@ -169,7 +172,10 @@ async def chat(req: ChatRequest) -> ChatResponse:
                 history=req.history,
             )
 
-    deps = AgentDeps(client_timezone=_validate_timezone(req.client_timezone))
+    deps = AgentDeps(
+        client_timezone=_validate_timezone(req.client_timezone),
+        locale="ru" if (req.client_locale or "").lower().startswith("ru") else "en",
+    )
 
     try:
         result = await agent.run(

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -7,6 +7,8 @@ class ChatRequest(BaseModel):
     message: str = Field(min_length=1, max_length=2000)
     history: list[Any] | None = None
     client_timezone: str | None = None
+    # Browser locale, e.g. "ru-RU" — sets the language the agent starts in
+    client_locale: str | None = None
 
 
 class TextReply(BaseModel):

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -192,9 +192,46 @@ def test_public_config():
     assert r.status_code == 200
     data = r.json()
     assert data["title"]
+    assert data["title_ru"]
+    assert data["greeting_ru"]
     assert len(data["schedule"]) == 7
     assert data["slot_minutes"] in (15, 30, 45, 60)
     assert isinstance(data["buttons"], list)
+    assert all("label_ru" in b for b in data["buttons"])
+
+
+def test_client_locale_sets_start_language():
+    seen = {}
+
+    def capture(messages, info):
+        seen["instructions"] = next(
+            (m.instructions for m in messages if getattr(m, "instructions", None)),
+            "",
+        )
+        return ModelResponse(parts=[TextPart("Привет!")])
+
+    with booking_agent.override(model=FunctionModel(capture)):
+        r = client.post(
+            "/api/chat",
+            json={
+                "message": "hello",
+                "client_timezone": "UTC",
+                "client_locale": "ru-RU",
+            },
+        )
+    assert r.status_code == 200
+    assert "start the\nconversation in Russian" in seen["instructions"]
+
+    with booking_agent.override(model=FunctionModel(capture)):
+        client.post(
+            "/api/chat",
+            json={
+                "message": "hello",
+                "client_timezone": "UTC",
+                "client_locale": "de-DE",
+            },
+        )
+    assert "start the\nconversation in English" in seen["instructions"]
 
 
 def test_admin_requires_auth():

--- a/frontend/src/admin/AdminApp.tsx
+++ b/frontend/src/admin/AdminApp.tsx
@@ -36,6 +36,9 @@ export default function AdminApp() {
   const [loadError, setLoadError] = useState('');
   const [saveState, setSaveState] = useState<SaveState>('idle');
   const [saveError, setSaveError] = useState('');
+  // which language the text fields below edit (visitors see the variant
+  // matching their browser locale: ru → Russian, everything else → English)
+  const [txtLang, setTxtLang] = useState<'en' | 'ru'>('en');
   const saveTimer = useRef<number | undefined>(undefined);
 
   async function load(activeCreds: string) {
@@ -189,6 +192,8 @@ export default function AdminApp() {
           ? `Error: ${saveError}`
           : 'Save';
 
+  const ru = txtLang === 'ru';
+
   return (
     <div className="adm-wrap">
       <div className="adm-col">
@@ -200,6 +205,26 @@ export default function AdminApp() {
           <a className="adm-open-chat" href="/">
             Open chat ↗
           </a>
+        </div>
+
+        <div className="adm-langtabs">
+          <button
+            type="button"
+            className={`adm-tab${ru ? '' : ' sel'}`}
+            onClick={() => setTxtLang('en')}
+          >
+            English
+          </button>
+          <button
+            type="button"
+            className={`adm-tab${ru ? ' sel' : ''}`}
+            onClick={() => setTxtLang('ru')}
+          >
+            Русский
+          </button>
+          <span className="adm-tab-hint">
+            Texts shown to visitors with this browser language
+          </span>
         </div>
 
         <div className="adm-card">
@@ -237,8 +262,10 @@ export default function AdminApp() {
             <input
               className="adm-input"
               maxLength={60}
-              value={cfg.title}
-              onChange={(e) => patch({ title: e.target.value })}
+              value={ru ? (cfg.title_ru ?? '') : cfg.title}
+              onChange={(e) =>
+                patch(ru ? { title_ru: e.target.value } : { title: e.target.value })
+              }
             />
           </div>
           <div>
@@ -246,8 +273,14 @@ export default function AdminApp() {
             <input
               className="adm-input"
               maxLength={100}
-              value={cfg.subtitle}
-              onChange={(e) => patch({ subtitle: e.target.value })}
+              value={ru ? (cfg.subtitle_ru ?? '') : cfg.subtitle}
+              onChange={(e) =>
+                patch(
+                  ru
+                    ? { subtitle_ru: e.target.value }
+                    : { subtitle: e.target.value },
+                )
+              }
             />
           </div>
         </div>
@@ -259,8 +292,14 @@ export default function AdminApp() {
             className="adm-textarea"
             rows={4}
             maxLength={1000}
-            value={cfg.greeting}
-            onChange={(e) => patch({ greeting: e.target.value })}
+            value={ru ? (cfg.greeting_ru ?? '') : cfg.greeting}
+            onChange={(e) =>
+              patch(
+                ru
+                  ? { greeting_ru: e.target.value }
+                  : { greeting: e.target.value },
+              )
+            }
           />
         </div>
 
@@ -270,10 +309,17 @@ export default function AdminApp() {
             <div className="adm-btn-row" key={i}>
               <input
                 className="adm-input"
-                placeholder="Button label"
+                placeholder={ru ? b.label || 'Надпись кнопки' : 'Button label'}
                 maxLength={40}
-                value={b.label}
-                onChange={(e) => patchButton(i, { label: e.target.value })}
+                value={ru ? (b.label_ru ?? '') : b.label}
+                onChange={(e) =>
+                  patchButton(
+                    i,
+                    ru
+                      ? { label_ru: e.target.value }
+                      : { label: e.target.value },
+                  )
+                }
               />
               <select
                 className="adm-select"
@@ -399,7 +445,8 @@ export default function AdminApp() {
           <div className="adm-label">About me — agent knowledge base</div>
           <div className="adm-hint">
             Experience, stack, projects — the agent answers questions about you from
-            this text
+            this text. One text for all languages: the agent replies in the
+            visitor's language automatically.
           </div>
           <textarea
             className="adm-textarea"

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -5,6 +5,7 @@ const API_URL: string = import.meta.env.VITE_API_URL ?? '';
 export async function sendChat(
   message: string,
   history: unknown | null,
+  locale: string,
 ): Promise<ChatResponse> {
   const res = await fetch(`${API_URL}/api/chat`, {
     method: 'POST',
@@ -13,6 +14,7 @@ export async function sendChat(
       message,
       history,
       client_timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+      client_locale: locale,
     }),
   });
   if (!res.ok) {

--- a/frontend/src/components/ChatApp.tsx
+++ b/frontend/src/components/ChatApp.tsx
@@ -1,6 +1,7 @@
 import dayjs from 'dayjs';
 import { useEffect, useRef, useState } from 'react';
 import { fetchConfig, sendChat } from '../api';
+import { LOCALE, fmtDay, pickText } from '../locale';
 import type { AgentReply, ChatItem, SiteConfig } from '../types';
 import StreamingText from './StreamingText';
 import ConfirmCard from './widgets/ConfirmCard';
@@ -11,11 +12,15 @@ import SuccessCard from './widgets/SuccessCard';
 const DEFAULT_CONFIG: SiteConfig = {
   title: "Hi, I'm Vsevolod",
   subtitle: 'Senior AI Engineer at OTP Group',
+  title_ru: 'Привет, я Всеволод',
+  subtitle_ru: 'Senior AI Engineer в OTP Group',
   avatar: null,
   greeting:
     'This is my AI agent — it can tell you about me\nand book a meeting with me.',
+  greeting_ru:
+    'Это мой AI-агент — он может рассказать обо мне\nи записать вас на встречу со мной.',
   buttons: [
-    { label: 'About Vsevolod', kind: 'about', url: '' },
+    { label: 'About Vsevolod', label_ru: 'О Всеволоде', kind: 'about', url: '' },
     { label: 'GitHub ↗', kind: 'link', url: 'https://github.com/vsezol' },
     { label: 'LinkedIn ↗', kind: 'link', url: 'https://www.linkedin.com/in/vsezol' },
     { label: 'Telegram ↗', kind: 'link', url: 'https://t.me/vsezol' },
@@ -25,13 +30,22 @@ const DEFAULT_CONFIG: SiteConfig = {
   tz_label: '',
 };
 
-const PLACEHOLDERS = [
-  'Tell me about Vsevolod',
-  "Let's meet tomorrow at 4 pm",
-  'Book a call on Friday at 11:00',
-  'I want to talk to Seva — my email is you@example.com',
-  'What does Vsevolod work on?',
-];
+const PLACEHOLDERS: Record<'en' | 'ru', string[]> = {
+  en: [
+    'Tell me about Vsevolod',
+    "Let's meet tomorrow at 4 pm",
+    'Book a call on Friday at 11:00',
+    'I want to talk to Seva — my email is you@example.com',
+    'What does Vsevolod work on?',
+  ],
+  ru: [
+    'Расскажи о Всеволоде',
+    'Давай встретимся завтра в 16:00',
+    'Забронируй звонок в пятницу в 11:00',
+    'Хочу поговорить с Севой — моя почта you@example.com',
+    'Над чем работает Всеволод?',
+  ],
+};
 
 const PHRASES: Record<'en' | 'ru', string[]> = {
   en: [
@@ -64,7 +78,7 @@ export default function ChatApp() {
   const [busy, setBusy] = useState(false);
   const [started, setStarted] = useState(false);
   const [focus, setFocus] = useState(false);
-  const [lang, setLang] = useState<'en' | 'ru'>('en');
+  const [lang, setLang] = useState<'en' | 'ru'>(LOCALE);
   const [placeholderIdx, setPlaceholderIdx] = useState(0);
   const historyRef = useRef<unknown | null>(null);
   const chatRef = useRef<HTMLDivElement>(null);
@@ -129,14 +143,17 @@ export default function ChatApp() {
     const text = message.trim();
     if (!text) return;
     setStarted(true);
-    if (/[а-яё]/i.test(text)) setLang('ru');
-    else if (/[a-z]/i.test(text)) setLang('en');
+    // widget events are internal English strings — not a language signal
+    if (!text.startsWith('[widget]')) {
+      if (/[а-яё]/i.test(text)) setLang('ru');
+      else if (/[a-z]/i.test(text)) setLang('en');
+    }
     if (bubble) {
       append({ kind: 'text', id: uid(), role: 'user', text: bubble });
     }
     setBusy(true);
     try {
-      const { reply, history } = await sendChat(text, historyRef.current);
+      const { reply, history } = await sendChat(text, historyRef.current, LOCALE);
       historyRef.current = history;
       const textItem: ChatItem = {
         kind: 'text',
@@ -239,6 +256,7 @@ export default function ChatApp() {
               <EmailWidget
                 prefill={item.prefill}
                 disabled={busy}
+                lang={lang}
                 onApprove={(email) => {
                   resolveWidget(item.id, email);
                   void send(`[widget] I confirm my email: ${email}`, null);
@@ -260,12 +278,13 @@ export default function ChatApp() {
               <DateTimeWidget
                 prefillStart={item.prefillStart}
                 disabled={busy}
+                lang={lang}
                 slotMinutes={config.slot_minutes}
                 schedule={config.schedule}
                 onApprove={(startIso) => {
                   resolveWidget(
                     item.id,
-                    dayjs(startIso).format('ddd, MMM D · HH:mm'),
+                    `${fmtDay(dayjs(startIso), lang)} · ${dayjs(startIso).format('HH:mm')}`,
                   );
                   void send(
                     `[widget] I confirm the meeting time: ${startIso}`,
@@ -292,6 +311,7 @@ export default function ChatApp() {
                 email={item.email}
                 tzLabel={config.tz_label}
                 disabled={busy}
+                lang={lang}
                 onBook={() => {
                   resolveWidget(
                     item.id,
@@ -334,22 +354,27 @@ export default function ChatApp() {
   const avatarUrl = config.avatar ?? '/my-avatar.webp';
   const canSend = Boolean(draft.trim()) && !busy;
 
-  const chips = config.buttons.map((b, i) =>
-    b.kind === 'link' ? (
+  const title = pickText(config.title, config.title_ru);
+  const subtitle = pickText(config.subtitle, config.subtitle_ru);
+  const greeting = pickText(config.greeting, config.greeting_ru);
+
+  const chips = config.buttons.map((b, i) => {
+    const label = pickText(b.label, b.label_ru);
+    return b.kind === 'link' ? (
       <a key={i} className="chip" href={b.url} target="_blank" rel="noreferrer">
-        {b.label}
+        {label}
       </a>
     ) : (
       <button
         key={i}
         type="button"
         className="chip"
-        onClick={() => void send(b.label)}
+        onClick={() => void send(label)}
       >
-        {b.label}
+        {label}
       </button>
-    ),
-  );
+    );
+  });
 
   return (
     <div className="app">
@@ -363,9 +388,9 @@ export default function ChatApp() {
                 style={{ backgroundImage: `url("${avatarUrl}")` }}
               />
             </div>
-            <h1 className="hero-title">{config.title}</h1>
-            <div className="hero-sub">{config.subtitle}</div>
-            <p className="hero-intro">{config.greeting}</p>
+            <h1 className="hero-title">{title}</h1>
+            <div className="hero-sub">{subtitle}</div>
+            <p className="hero-intro">{greeting}</p>
           </div>
         ) : (
           <div className="thread">
@@ -375,8 +400,8 @@ export default function ChatApp() {
                 style={{ backgroundImage: `url("${avatarUrl}")` }}
               />
               <div className="thread-intro-info">
-                <div className="thread-intro-title">{config.title}</div>
-                <div className="thread-intro-sub">{config.subtitle}</div>
+                <div className="thread-intro-title">{title}</div>
+                <div className="thread-intro-sub">{subtitle}</div>
               </div>
             </div>
             {items.map(renderItem)}
@@ -393,8 +418,10 @@ export default function ChatApp() {
             value={draft}
             placeholder={
               started
-                ? 'Message the agent…'
-                : PLACEHOLDERS[placeholderIdx % PLACEHOLDERS.length]
+                ? LOCALE === 'ru'
+                  ? 'Напишите агенту…'
+                  : 'Message the agent…'
+                : PLACEHOLDERS[LOCALE][placeholderIdx % PLACEHOLDERS[LOCALE].length]
             }
             onChange={(e) => setDraft(e.target.value)}
             onFocus={() => setFocus(true)}

--- a/frontend/src/components/widgets/ConfirmCard.tsx
+++ b/frontend/src/components/widgets/ConfirmCard.tsx
@@ -1,4 +1,26 @@
 import dayjs from 'dayjs';
+import { fmtDay } from '../../locale';
+
+const T = {
+  en: {
+    title: 'Meeting with Vsevolod Zolotov',
+    when: 'When',
+    timezone: 'Timezone',
+    guest: 'Guest',
+    where: 'Where',
+    book: 'Book the meeting',
+    decline: 'Decline',
+  },
+  ru: {
+    title: 'Встреча со Всеволодом Золотовым',
+    when: 'Когда',
+    timezone: 'Часовой пояс',
+    guest: 'Гость',
+    where: 'Где',
+    book: 'Забронировать встречу',
+    decline: 'Отклонить',
+  },
+};
 
 interface Props {
   start: string;
@@ -6,6 +28,7 @@ interface Props {
   email: string;
   tzLabel?: string;
   disabled: boolean;
+  lang?: 'en' | 'ru';
   onBook: () => void;
   onDecline: () => void;
 }
@@ -16,40 +39,42 @@ export default function ConfirmCard({
   email,
   tzLabel,
   disabled,
+  lang = 'en',
   onBook,
   onDecline,
 }: Props) {
+  const t = T[lang];
   const startAt = dayjs(start);
   const endAt = startAt.add(durationMinutes, 'minute');
-  const when = `${startAt.format('ddd, MMM D')} · ${startAt.format('HH:mm')}–${endAt.format('HH:mm')}`;
+  const when = `${fmtDay(startAt, lang)} · ${startAt.format('HH:mm')}–${endAt.format('HH:mm')}`;
   const tz = Intl.DateTimeFormat().resolvedOptions().timeZone || tzLabel || '';
 
   return (
     <div className="wcard">
-      <div className="confirm-title">Meeting with Vsevolod Zolotov</div>
+      <div className="confirm-title">{t.title}</div>
       <div className="confirm-rows">
         <div className="crow">
-          <span className="k">When</span>
+          <span className="k">{t.when}</span>
           <span className="v">{when}</span>
         </div>
         <div className="crow">
-          <span className="k">Timezone</span>
+          <span className="k">{t.timezone}</span>
           <span className="v">{tz}</span>
         </div>
         <div className="crow">
-          <span className="k">Guest</span>
+          <span className="k">{t.guest}</span>
           <span className="v">{email}</span>
         </div>
         <div className="crow">
-          <span className="k">Where</span>
+          <span className="k">{t.where}</span>
           <span className="v">Google Meet</span>
         </div>
       </div>
       <button type="button" className="btn-book" disabled={disabled} onClick={onBook}>
-        Book the meeting
+        {t.book}
       </button>
       <button type="button" className="btn-text" disabled={disabled} onClick={onDecline}>
-        Decline
+        {t.decline}
       </button>
     </div>
   );

--- a/frontend/src/components/widgets/DateTimeWidget.tsx
+++ b/frontend/src/components/widgets/DateTimeWidget.tsx
@@ -1,5 +1,6 @@
 import dayjs, { Dayjs } from 'dayjs';
 import { useEffect, useMemo, useRef, useState } from 'react';
+import { fmtDay } from '../../locale';
 import type { DayCfg } from '../../types';
 
 const ITEM_H = 40;
@@ -47,9 +48,20 @@ function nearestSlot(slots: string[], time: string): string {
   return best;
 }
 
+const DOW: Record<'en' | 'ru', string[]> = {
+  en: ['Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa', 'Su'],
+  ru: ['Пн', 'Вт', 'Ср', 'Чт', 'Пт', 'Сб', 'Вс'],
+};
+
+const BTNS = {
+  en: { approve: 'Approve', decline: 'Decline' },
+  ru: { approve: 'Подтвердить', decline: 'Отклонить' },
+};
+
 interface Props {
   prefillStart: string | null;
   disabled: boolean;
+  lang?: 'en' | 'ru';
   slotMinutes: number;
   schedule: DayCfg[];
   onApprove: (startIso: string) => void;
@@ -59,6 +71,7 @@ interface Props {
 export default function DateTimeWidget({
   prefillStart,
   disabled,
+  lang = 'en',
   slotMinutes,
   schedule,
   onApprove,
@@ -182,12 +195,12 @@ export default function DateTimeWidget({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [view, today, schedule]);
 
-  const selLabel = `${dayjs(selDate).format('ddd, MMM D')} · ${selTime}`;
+  const selLabel = `${fmtDay(dayjs(selDate), lang)} · ${selTime}`;
 
   return (
     <div className="wcard dt">
       <div className="cal-head">
-        <div className="cal-label">{view.format('MMMM YYYY')}</div>
+        <div className="cal-label">{view.locale(lang).format('MMMM YYYY')}</div>
         <div className="cal-nav">
           <button
             type="button"
@@ -207,13 +220,9 @@ export default function DateTimeWidget({
       </div>
 
       <div className="cal-dow">
-        <span>Mo</span>
-        <span>Tu</span>
-        <span>We</span>
-        <span>Th</span>
-        <span>Fr</span>
-        <span>Sa</span>
-        <span>Su</span>
+        {DOW[lang].map((d) => (
+          <span key={d}>{d}</span>
+        ))}
       </div>
 
       <div className="cal-grid">
@@ -270,10 +279,10 @@ export default function DateTimeWidget({
             onApprove(dayjs(`${selDate}T${selTime}`).format('YYYY-MM-DDTHH:mm:ssZ'))
           }
         >
-          Approve
+          {BTNS[lang].approve}
         </button>
         <button type="button" className="btn-ghost" disabled={disabled} onClick={onDecline}>
-          Decline
+          {BTNS[lang].decline}
         </button>
       </div>
     </div>

--- a/frontend/src/components/widgets/EmailWidget.tsx
+++ b/frontend/src/components/widgets/EmailWidget.tsx
@@ -2,9 +2,25 @@ import { useState } from 'react';
 
 const EMAIL_RE = /^[\w.+-]+@[\w-]+(\.[\w-]+)+$/;
 
+const T = {
+  en: {
+    label: 'Confirm email',
+    error: "Hmm, that doesn't look like a valid email",
+    approve: 'Approve',
+    decline: 'Decline',
+  },
+  ru: {
+    label: 'Подтвердите почту',
+    error: 'Хм, это не похоже на настоящую почту',
+    approve: 'Подтвердить',
+    decline: 'Отклонить',
+  },
+};
+
 interface Props {
   prefill: string | null;
   disabled: boolean;
+  lang?: 'en' | 'ru';
   onApprove: (email: string) => void;
   onDecline: () => void;
 }
@@ -12,16 +28,18 @@ interface Props {
 export default function EmailWidget({
   prefill,
   disabled,
+  lang = 'en',
   onApprove,
   onDecline,
 }: Props) {
   const [email, setEmail] = useState(prefill ?? '');
   const [error, setError] = useState('');
+  const t = T[lang];
 
   function approve() {
     const value = email.trim();
     if (!EMAIL_RE.test(value)) {
-      setError("Hmm, that doesn't look like a valid email");
+      setError(t.error);
       return;
     }
     onApprove(value);
@@ -29,7 +47,7 @@ export default function EmailWidget({
 
   return (
     <div className="wcard">
-      <div className="wlabel">Confirm email</div>
+      <div className="wlabel">{t.label}</div>
       <input
         className="winput"
         type="email"
@@ -52,10 +70,10 @@ export default function EmailWidget({
       {error && <div className="werror">{error}</div>}
       <div className="wbtns">
         <button type="button" className="btn-primary" disabled={disabled} onClick={approve}>
-          Approve
+          {t.approve}
         </button>
         <button type="button" className="btn-ghost" disabled={disabled} onClick={onDecline}>
-          Decline
+          {t.decline}
         </button>
       </div>
     </div>

--- a/frontend/src/components/widgets/SuccessCard.tsx
+++ b/frontend/src/components/widgets/SuccessCard.tsx
@@ -1,5 +1,6 @@
 import dayjs from 'dayjs';
 import { useEffect, useRef, useState } from 'react';
+import { fmtDay } from '../../locale';
 
 interface Props {
   meetUrl: string;
@@ -14,7 +15,7 @@ export default function SuccessCard({ meetUrl, start, email, lang = 'en' }: Prop
 
   useEffect(() => () => window.clearTimeout(timer.current), []);
 
-  const when = dayjs(start).format('ddd, MMM D · HH:mm');
+  const when = `${fmtDay(dayjs(start), lang)} · ${dayjs(start).format('HH:mm')}`;
   const displayUrl = meetUrl.replace(/^https?:\/\//, '');
 
   function copy() {
@@ -32,7 +33,9 @@ export default function SuccessCard({ meetUrl, start, email, lang = 'en' }: Prop
     <div className="success-card">
       <div className="success-head">
         <span className="success-check">✓</span>
-        <span className="success-title">Meeting booked</span>
+        <span className="success-title">
+          {lang === 'ru' ? 'Встреча забронирована' : 'Meeting booked'}
+        </span>
       </div>
       <div className="success-text">
         {lang === 'ru'

--- a/frontend/src/locale.ts
+++ b/frontend/src/locale.ts
@@ -1,0 +1,28 @@
+import dayjs, { type Dayjs } from 'dayjs';
+import 'dayjs/locale/ru';
+
+export type Locale = 'en' | 'ru';
+
+function detect(): Locale {
+  // ?lang=ru / ?lang=en overrides the browser locale (handy for testing)
+  const forced = new URLSearchParams(window.location.search).get('lang');
+  if (forced === 'ru' || forced === 'en') return forced;
+  return /^ru\b/i.test(navigator.language ?? '') ? 'ru' : 'en';
+}
+
+/** Site locale: Russian browsers get Russian, everyone else English. */
+export const LOCALE: Locale = detect();
+
+dayjs.locale(LOCALE);
+
+/** Pick the localized variant, falling back to English when RU is empty. */
+export function pickText(en: string, ru: string | null | undefined): string {
+  return LOCALE === 'ru' && ru ? ru : en;
+}
+
+/** "ddd, MMM D" for English, natural "пн, 6 июля" for Russian. */
+export function fmtDay(d: Dayjs, lang: Locale): string {
+  return lang === 'ru'
+    ? d.locale('ru').format('dd, D MMMM')
+    : d.locale('en').format('ddd, MMM D');
+}

--- a/frontend/src/styles/admin.css
+++ b/frontend/src/styles/admin.css
@@ -371,3 +371,33 @@
   padding: 40px 0;
   text-align: center;
 }
+
+/* ---------- language tabs for localized texts ---------- */
+.adm-langtabs {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.adm-tab {
+  font: 600 13px var(--font);
+  color: var(--muted);
+  background: transparent;
+  border: 1px solid var(--line-14);
+  border-radius: 999px;
+  padding: 8px 18px;
+  cursor: pointer;
+  transition: border-color 0.2s ease, color 0.2s ease, background 0.2s ease;
+}
+
+.adm-tab.sel {
+  color: var(--accent);
+  border-color: rgba(110, 155, 255, 0.45);
+  background: rgba(110, 155, 255, 0.1);
+}
+
+.adm-tab-hint {
+  font: 400 12px var(--font);
+  color: var(--muted);
+}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -30,6 +30,8 @@ export interface ChatResponse {
 
 export interface ButtonCfg {
   label: string;
+  /** Russian label; empty means "same as label" */
+  label_ru?: string;
   kind: 'link' | 'about';
   url: string;
 }
@@ -43,8 +45,11 @@ export interface DayCfg {
 export interface SiteConfig {
   title: string;
   subtitle: string;
+  title_ru?: string;
+  subtitle_ru?: string;
   avatar: string | null;
   greeting: string;
+  greeting_ru?: string;
   buttons: ButtonCfg[];
   schedule: DayCfg[];
   slot_minutes: number;


### PR DESCRIPTION
## What
- **Locale detection**: Russian browser locale → the whole UI and the agent's opening language are Russian; any other locale → English. `?lang=ru|en` query override for testing.
- **Localized UI**: hero/intro, chips, rotating placeholders, composer, and all widgets — calendar (Пн–Вс, «июль 2026», «пн, 6 июля · 17:30»), email, confirm card, success card.
- **Per-locale texts in admin**: English/Русский tabs above the text fields; title/subtitle/greeting/button labels stored per locale (`*_ru` fields, empty RU falls back to EN). Bio stays a single field — the agent answers in the visitor's language on its own.
- **Agent**: `client_locale` is sent with every chat request; instructions now open the conversation in the locale language and mirror the visitor afterwards.
- **Fix**: internal `[widget]` events no longer flip the conversation language to English (they're English strings), so widgets stay in the visitor's language through the whole flow.

Backwards compatible: the existing config on the Railway volume loads as-is; new fields get Russian defaults.

## Tests
13/13 backend tests pass (new: locale → start language in instructions, ru fields in public config). Full RU booking flow verified in preview against both the scripted mock and the real backend in demo mode; admin tabs roundtrip verified (RU edit saved, EN untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)