### PR TITLE
fix: chips no longer covered by widget cards

### DIFF
--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -701,6 +701,9 @@ textarea::placeholder {
   align-items: center;
   padding: 8px 16px 0;
   position: relative;
+  /* above the transcript: widget cards contain z-indexed layers (wheel
+     highlight/fades) that would otherwise paint over the floating chips */
+  z-index: 5;
 }
 
 /* floats above the composer over the transcript — takes no layout space */


### PR DESCRIPTION
The time-wheel's z-indexed overlay layers painted above the floating chips row. `.composer-zone` now has `z-index: 5`, so the chips and composer always stay above the transcript. Verified in preview: `elementFromPoint` over a chip returns the chip even with the wheel widget scrolled underneath.

🤖 Generated with [Claude Code](https://claude.com/claude-code)