### PR TITLE
fix: transient-error retries + unrestricted languages

### DIFF
--- a/backend/app/agent.py
+++ b/backend/app/agent.py
@@ -150,12 +150,12 @@ def system_instructions(ctx: RunContext[AgentDeps]) -> str:
 You are the personal AI agent of {settings.owner_name} on his personal site.
 Your job: chat with visitors and book meetings with him.
 
-LANGUAGE: the visitor's browser locale is "{ctx.deps.locale}" — start the
-conversation in {start_language} and stay in it until the visitor writes in
-a different language; from then on mirror the language of their most recent
-message (Russian → Russian, English → English, and so on). Messages starting
-with "[widget]" are system events, not language cues — they never change
-the language.
+LANGUAGE: you speak EVERY language fluently — never claim to be limited to
+specific ones. The visitor's browser locale is "{ctx.deps.locale}" — start the
+conversation in {start_language}. The moment the visitor writes in any other
+language (Japanese, German, Spanish, anything), switch and keep mirroring
+the language of their most recent message. Messages starting with "[widget]"
+are system events, not language cues — they never change the language.
 
 About {settings.owner_name} — your ONLY source of facts about him:
 {bio}

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 from zoneinfo import ZoneInfo
 
@@ -5,6 +6,7 @@ from fastapi import FastAPI, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from pydantic import ValidationError
+from pydantic_ai.exceptions import ModelHTTPError
 from pydantic_ai.messages import (
     ModelMessagesTypeAdapter,
     ModelRequest,
@@ -99,6 +101,21 @@ def public_config() -> dict:
     }
 
 
+# Gemini occasionally 503s ("high demand") on both the primary and the
+# fallback model at once — worth a couple of quick retries before giving up.
+TRANSIENT_STATUS = {429, 500, 502, 503, 504}
+AGENT_RUN_ATTEMPTS = 3
+RETRY_BACKOFF_SECONDS = 0.8
+
+
+def _is_transient(exc: BaseException) -> bool:
+    if isinstance(exc, ModelHTTPError):
+        return exc.status_code in TRANSIENT_STATUS
+    if isinstance(exc, BaseExceptionGroup):
+        return any(_is_transient(e) for e in exc.exceptions)
+    return False
+
+
 def _validate_timezone(tz: str | None) -> str:
     if not tz:
         return "UTC"
@@ -177,19 +194,38 @@ async def chat(req: ChatRequest) -> ChatResponse:
         locale="ru" if (req.client_locale or "").lower().startswith("ru") else "en",
     )
 
-    try:
-        result = await agent.run(
-            req.message,
-            deps=deps,
-            message_history=history,
-            usage_limits=UsageLimits(request_limit=8),
-        )
-    except Exception:
-        logger.exception("Agent run failed")
-        raise HTTPException(
-            status_code=502,
-            detail="The agent is temporarily unavailable. Please try again.",
-        )
+    result = None
+    for attempt in range(1, AGENT_RUN_ATTEMPTS + 1):
+        try:
+            result = await agent.run(
+                req.message,
+                deps=deps,
+                message_history=history,
+                usage_limits=UsageLimits(request_limit=8),
+            )
+            break
+        except Exception as exc:
+            # never re-run a conversation that already created a booking —
+            # the meeting exists, so tell the visitor instead of erroring
+            if deps.booking is not None:
+                logger.exception("Agent run failed after booking; replying booked")
+                return ChatResponse(
+                    reply=_build_reply("", deps), history=req.history or []
+                )
+            if attempt < AGENT_RUN_ATTEMPTS and _is_transient(exc):
+                logger.warning(
+                    "Transient model error (attempt %d/%d): %s",
+                    attempt,
+                    AGENT_RUN_ATTEMPTS,
+                    exc,
+                )
+                await asyncio.sleep(RETRY_BACKOFF_SECONDS * attempt)
+                continue
+            logger.exception("Agent run failed")
+            raise HTTPException(
+                status_code=502,
+                detail="The agent is temporarily unavailable. Please try again.",
+            )
 
     return ChatResponse(
         reply=_build_reply(result.output, deps),

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -167,6 +167,45 @@ def test_plain_text_time_ask_becomes_widget():
     assert r.json()["reply"]["type"] == "ask_datetime"
 
 
+def test_transient_503_is_retried():
+    from pydantic_ai.exceptions import ModelHTTPError
+
+    calls = {"n": 0}
+
+    def flaky(messages, info):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise ModelHTTPError(
+                status_code=503,
+                model_name="gemini-2.5-flash",
+                body={"error": {"status": "UNAVAILABLE"}},
+            )
+        return ModelResponse(parts=[TextPart("Recovered!")])
+
+    with booking_agent.override(model=FunctionModel(flaky)):
+        r = client.post(
+            "/api/chat", json={"message": "hi", "client_timezone": "UTC"}
+        )
+    assert r.status_code == 200
+    assert r.json()["reply"]["message"] == "Recovered!"
+    assert calls["n"] == 2
+
+
+def test_non_transient_error_fails_fast():
+    calls = {"n": 0}
+
+    def broken(messages, info):
+        calls["n"] += 1
+        raise RuntimeError("boom")
+
+    with booking_agent.override(model=FunctionModel(broken)):
+        r = client.post(
+            "/api/chat", json={"message": "hi", "client_timezone": "UTC"}
+        )
+    assert r.status_code == 502
+    assert calls["n"] == 1
+
+
 def test_message_limit():
     from pydantic_ai.messages import (
         ModelMessagesTypeAdapter,

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -2,21 +2,31 @@ import type { ChatResponse, SiteConfig } from './types';
 
 const API_URL: string = import.meta.env.VITE_API_URL ?? '';
 
+// statuses where the server definitely did not book anything — safe to retry
+const RETRYABLE = new Set([429, 502, 503]);
+
 export async function sendChat(
   message: string,
   history: unknown | null,
   locale: string,
 ): Promise<ChatResponse> {
-  const res = await fetch(`${API_URL}/api/chat`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      message,
-      history,
-      client_timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
-      client_locale: locale,
-    }),
-  });
+  const post = () =>
+    fetch(`${API_URL}/api/chat`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        message,
+        history,
+        client_timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+        client_locale: locale,
+      }),
+    });
+
+  let res = await post();
+  if (RETRYABLE.has(res.status)) {
+    await new Promise((r) => setTimeout(r, 1500));
+    res = await post();
+  }
   if (!res.ok) {
     throw new Error(`Request failed with status ${res.status}`);
   }


### PR DESCRIPTION
## Failures («Что-то пошло не так»)
Railway logs show Gemini answering **503 UNAVAILABLE (high demand) on both the primary and the fallback model simultaneously**, so FallbackModel gave up and the API returned 502.

- backend: `agent.run` retries up to 3 attempts with 0.8s/1.6s backoff when the error is transient (429/5xx, including exception groups where any sub-error is transient)
- if a run dies *after* `book_meeting` succeeded, the API now replies `booked` instead of 502 — a conversation that booked is never re-run (no double bookings)
- frontend: one retry on 429/502/503 after 1.5s — statuses where the server can't have booked

## Languages
The agent refused Japanese («могу общаться только на русском или английском») — the instruction's 'Russian → Russian, English → English' examples read as an exhaustive list. Now: *you speak EVERY language fluently, never claim to be limited*; locale only picks the opening language.

## Tests
15/15 pass (new: 503 retried then succeeds; non-transient RuntimeError fails fast without retry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)