### PR TITLE
feat: resumable server-side sessions + first-load animation fix

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -39,6 +39,8 @@ class Settings(BaseSettings):
     max_history_messages: int = 120
     # Hard cap of visitor messages per conversation (token protection)
     max_user_messages: int = 20
+    # Sessions idle longer than this are dropped
+    session_ttl_days: int = 7
 
     # Admin API auth (HTTP Basic; the admin UI lives in the site SPA at /#admin)
     admin_user: str = "admin"

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -26,6 +26,7 @@ from .agent import (
 )
 from .config import settings
 from .rate_limit import RateLimiter
+from .sessions import session_store
 from .schemas import (
     AskConfirmReply,
     AskDateTimeReply,
@@ -99,6 +100,42 @@ def public_config() -> dict:
         "slot_minutes": cfg.slot_minutes,
         "tz_label": cfg.tz_label,
     }
+
+
+ASK_TYPES = {"ask_email", "ask_datetime", "ask_confirm"}
+
+
+def _resolve_pending_widget(transcript: list[dict], message: str) -> None:
+    """Mark the latest unresolved widget entry with the visitor's answer.
+
+    "[widget] ..." messages answer the most recent ask_* reply; the stored
+    value lets the frontend render a summary chip on session restore.
+    """
+    for entry in reversed(transcript):
+        if entry.get("kind") != "agent":
+            continue
+        reply = entry.get("reply") or {}
+        if reply.get("type") not in ASK_TYPES:
+            continue
+        if entry.get("resolved") is None:
+            if message.startswith(
+                ("[widget] I confirm my email:", "[widget] I confirm the meeting time:")
+            ):
+                entry["resolved"] = message.split(":", 1)[1].strip()
+            elif message.startswith("[widget] Confirmed"):
+                entry["resolved"] = "booked"
+            else:
+                entry["resolved"] = "declined"
+        return
+
+
+@app.get("/api/session/{session_id}")
+def get_session(session_id: str) -> dict:
+    """Transcript of a previous conversation, for restoring the chat UI."""
+    session = session_store.load(session_id)
+    if session is None or not session.transcript:
+        raise HTTPException(status_code=404, detail="Session not found")
+    return {"session_id": session.id, "transcript": session.transcript}
 
 
 # Gemini occasionally 503s ("high demand") on both the primary and the
@@ -177,6 +214,18 @@ async def chat(req: ChatRequest) -> ChatResponse:
         except ValidationError:
             raise HTTPException(status_code=400, detail="Invalid history payload")
 
+    # the server-held session history wins over the client copy
+    session = session_store.load(req.session_id) if req.session_id else None
+    if session is None:
+        session = session_store.create()
+    if session.history:
+        try:
+            history = ModelMessagesTypeAdapter.validate_python(session.history)
+        except ValidationError:
+            logger.warning("Corrupt history in session %s, resetting", session.id)
+            session.history = []
+
+    if history is not None:
         user_turns = sum(
             1
             for m in history
@@ -186,7 +235,8 @@ async def chat(req: ChatRequest) -> ChatResponse:
         if user_turns >= settings.max_user_messages:
             return ChatResponse(
                 reply=TextReply(message=LIMIT_REACHED_MESSAGE),
-                history=req.history,
+                history=req.history or [],
+                session_id=session.id,
             )
 
     deps = AgentDeps(
@@ -210,7 +260,9 @@ async def chat(req: ChatRequest) -> ChatResponse:
             if deps.booking is not None:
                 logger.exception("Agent run failed after booking; replying booked")
                 return ChatResponse(
-                    reply=_build_reply("", deps), history=req.history or []
+                    reply=_build_reply("", deps),
+                    history=req.history or [],
+                    session_id=session.id,
                 )
             if attempt < AGENT_RUN_ATTEMPTS and _is_transient(exc):
                 logger.warning(
@@ -227,9 +279,19 @@ async def chat(req: ChatRequest) -> ChatResponse:
                 detail="The agent is temporarily unavailable. Please try again.",
             )
 
-    return ChatResponse(
-        reply=_build_reply(result.output, deps),
-        history=ModelMessagesTypeAdapter.dump_python(
-            result.all_messages(), mode="json"
-        ),
+    reply = _build_reply(result.output, deps)
+
+    session.history = ModelMessagesTypeAdapter.dump_python(
+        result.all_messages(), mode="json"
     )
+    if req.message.startswith("[widget]"):
+        _resolve_pending_widget(session.transcript, req.message)
+    else:
+        session.transcript.append({"kind": "user", "text": req.message})
+    session.transcript.append(
+        {"kind": "agent", "reply": reply.model_dump(), "resolved": None}
+    )
+    session_store.save(session)
+    session_store.sweep()
+
+    return ChatResponse(reply=reply, history=session.history, session_id=session.id)

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -9,6 +9,8 @@ class ChatRequest(BaseModel):
     client_timezone: str | None = None
     # Browser locale, e.g. "ru-RU" — sets the language the agent starts in
     client_locale: str | None = None
+    # Server-side session to resume; a new one is created when absent/expired
+    session_id: str | None = Field(default=None, max_length=64)
 
 
 class TextReply(BaseModel):
@@ -57,3 +59,4 @@ Reply = Annotated[
 class ChatResponse(BaseModel):
     reply: Reply
     history: list[Any]
+    session_id: str | None = None

--- a/backend/app/sessions.py
+++ b/backend/app/sessions.py
@@ -1,0 +1,132 @@
+"""Server-side chat sessions: visitors resume conversations by session id.
+
+Each session is a JSON file next to the admin config (on Railway — the
+/data volume): the pydantic-ai message history plus a UI transcript the
+frontend re-renders on return visits. Sessions idle for longer than the
+TTL are dropped.
+"""
+
+import json
+import logging
+import re
+import threading
+import time
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+from .admin_config import store
+from .config import settings
+
+logger = logging.getLogger(__name__)
+
+VALID_ID = re.compile(r"^[0-9a-f]{32}$")
+
+SWEEP_INTERVAL_SECONDS = 15 * 60
+
+# generous cap so a single session file can't grow unbounded
+MAX_TRANSCRIPT_ENTRIES = 200
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+@dataclass
+class Session:
+    id: str
+    history: list[Any] = field(default_factory=list)
+    transcript: list[dict[str, Any]] = field(default_factory=list)
+    last_active: datetime = field(default_factory=_now)
+
+
+class SessionStore:
+    def __init__(self, directory: Path, ttl_days: int) -> None:
+        self.dir = directory
+        self.ttl = timedelta(days=ttl_days)
+        self._lock = threading.Lock()
+        self._last_sweep = 0.0
+
+    def _path(self, session_id: str) -> Path:
+        return self.dir / f"{session_id}.json"
+
+    def create(self) -> Session:
+        return Session(id=uuid.uuid4().hex)
+
+    def load(self, session_id: str) -> Session | None:
+        if not VALID_ID.match(session_id):
+            return None
+        try:
+            data = json.loads(self._path(session_id).read_text(encoding="utf-8"))
+            last_active = datetime.fromisoformat(data["last_active"])
+        except (OSError, ValueError, KeyError):
+            return None
+        if _now() - last_active > self.ttl:
+            self.delete(session_id)
+            return None
+        return Session(
+            id=session_id,
+            history=data.get("history") or [],
+            transcript=data.get("transcript") or [],
+            last_active=last_active,
+        )
+
+    def save(self, session: Session) -> None:
+        session.last_active = _now()
+        session.transcript = session.transcript[-MAX_TRANSCRIPT_ENTRIES:]
+        payload = json.dumps(
+            {
+                "history": session.history,
+                "transcript": session.transcript,
+                "last_active": session.last_active.isoformat(),
+            },
+            ensure_ascii=False,
+        )
+        with self._lock:
+            try:
+                self.dir.mkdir(parents=True, exist_ok=True)
+                self._path(session.id).write_text(payload, encoding="utf-8")
+            except OSError:
+                logger.exception("Failed to persist session %s", session.id)
+
+    def delete(self, session_id: str) -> None:
+        try:
+            self._path(session_id).unlink()
+        except OSError:
+            pass
+
+    def sweep(self, force: bool = False) -> None:
+        """Drop sessions idle beyond the TTL; throttled to run occasionally."""
+        with self._lock:
+            now = time.monotonic()
+            if not force and now - self._last_sweep < SWEEP_INTERVAL_SECONDS:
+                return
+            self._last_sweep = now
+        cutoff = _now() - self.ttl
+        try:
+            files = list(self.dir.glob("*.json"))
+        except OSError:
+            return
+        dropped = 0
+        for path in files:
+            try:
+                data = json.loads(path.read_text(encoding="utf-8"))
+                last_active = datetime.fromisoformat(data["last_active"])
+                expired = last_active < cutoff
+            except (OSError, ValueError, KeyError):
+                expired = True  # unreadable/corrupt — drop it
+            if expired:
+                try:
+                    path.unlink()
+                    dropped += 1
+                except OSError:
+                    pass
+        if dropped:
+            logger.info("Swept %d expired session(s)", dropped)
+
+
+session_store = SessionStore(
+    store.path.parent / "sessions", ttl_days=settings.session_ttl_days
+)

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -167,6 +167,106 @@ def test_plain_text_time_ask_becomes_widget():
     assert r.json()["reply"]["type"] == "ask_datetime"
 
 
+def _counting_model():
+    from pydantic_ai.messages import ModelRequest as MReq
+    from pydantic_ai.messages import UserPromptPart as UPart
+
+    def fn(messages, info):
+        n = sum(
+            1
+            for m in messages
+            if isinstance(m, MReq) and any(isinstance(p, UPart) for p in m.parts)
+        )
+        return ModelResponse(parts=[TextPart(f"turn {n}")])
+
+    return FunctionModel(fn)
+
+
+def test_session_keeps_context_server_side():
+    with booking_agent.override(model=_counting_model()):
+        r1 = client.post(
+            "/api/chat", json={"message": "hello", "client_timezone": "UTC"}
+        )
+        sid = r1.json()["session_id"]
+        assert sid
+        assert r1.json()["reply"]["message"] == "turn 1"
+
+        # no client history at all — context comes from the server session
+        r2 = client.post(
+            "/api/chat",
+            json={"message": "again", "session_id": sid, "client_timezone": "UTC"},
+        )
+    assert r2.json()["session_id"] == sid
+    assert r2.json()["reply"]["message"] == "turn 2"
+
+    r3 = client.get(f"/api/session/{sid}")
+    assert r3.status_code == 200
+    transcript = r3.json()["transcript"]
+    assert [e["kind"] for e in transcript] == ["user", "agent", "user", "agent"]
+    assert transcript[0]["text"] == "hello"
+
+    assert client.get("/api/session/" + "0" * 32).status_code == 404
+
+
+def test_widget_messages_resolve_transcript_entries():
+    from app.main import _resolve_pending_widget
+
+    transcript = [
+        {"kind": "user", "text": "book me"},
+        {"kind": "agent", "reply": {"type": "ask_email", "message": "?"}, "resolved": None},
+    ]
+    _resolve_pending_widget(transcript, "[widget] I confirm my email: a@b.co")
+    assert transcript[1]["resolved"] == "a@b.co"
+
+    transcript.append(
+        {
+            "kind": "agent",
+            "reply": {"type": "ask_datetime", "message": "?"},
+            "resolved": None,
+        }
+    )
+    _resolve_pending_widget(
+        transcript, "[widget] I confirm the meeting time: 2030-01-15T15:00:00+03:00"
+    )
+    assert transcript[2]["resolved"] == "2030-01-15T15:00:00+03:00"
+
+    transcript.append(
+        {
+            "kind": "agent",
+            "reply": {"type": "ask_confirm", "message": "?"},
+            "resolved": None,
+        }
+    )
+    _resolve_pending_widget(transcript, "[widget] I declined the booking confirmation.")
+    assert transcript[3]["resolved"] == "declined"
+
+
+def test_expired_session_is_dropped():
+    import json as jsonlib
+    from datetime import datetime, timedelta, timezone
+
+    from app.sessions import session_store
+
+    with booking_agent.override(model=_text_model("hi")):
+        r = client.post("/api/chat", json={"message": "hi", "client_timezone": "UTC"})
+    sid = r.json()["session_id"]
+
+    path = session_store._path(sid)
+    data = jsonlib.loads(path.read_text(encoding="utf-8"))
+    data["last_active"] = (
+        datetime.now(timezone.utc) - timedelta(days=8)
+    ).isoformat()
+    path.write_text(jsonlib.dumps(data), encoding="utf-8")
+
+    assert client.get(f"/api/session/{sid}").status_code == 404
+    assert not path.exists()
+
+    # sweep removes stale files too
+    path.write_text(jsonlib.dumps(data), encoding="utf-8")
+    session_store.sweep(force=True)
+    assert not path.exists()
+
+
 def test_transient_503_is_retried():
     from pydantic_ai.exceptions import ModelHTTPError
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -15,6 +15,7 @@
       content="Chat with Vsevolod's personal AI agent to book a meeting with him."
     />
     <link rel="icon" href="/favicon.ico" />
+    <link rel="preload" as="image" href="/my-avatar.webp" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,4 +1,4 @@
-import type { ChatResponse, SiteConfig } from './types';
+import type { ChatResponse, SessionResponse, SiteConfig } from './types';
 
 const API_URL: string = import.meta.env.VITE_API_URL ?? '';
 
@@ -9,6 +9,7 @@ export async function sendChat(
   message: string,
   history: unknown | null,
   locale: string,
+  sessionId: string | null,
 ): Promise<ChatResponse> {
   const post = () =>
     fetch(`${API_URL}/api/chat`, {
@@ -19,6 +20,7 @@ export async function sendChat(
         history,
         client_timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
         client_locale: locale,
+        session_id: sessionId,
       }),
     });
 
@@ -29,6 +31,14 @@ export async function sendChat(
   }
   if (!res.ok) {
     throw new Error(`Request failed with status ${res.status}`);
+  }
+  return res.json();
+}
+
+export async function fetchSession(sessionId: string): Promise<SessionResponse> {
+  const res = await fetch(`${API_URL}/api/session/${sessionId}`);
+  if (!res.ok) {
+    throw new Error(`Session request failed with status ${res.status}`);
   }
   return res.json();
 }

--- a/frontend/src/components/ChatApp.tsx
+++ b/frontend/src/components/ChatApp.tsx
@@ -1,10 +1,15 @@
 import dayjs from 'dayjs';
 import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { fetchConfig, sendChat } from '../api';
+import { fetchConfig, fetchSession, sendChat } from '../api';
 import i18n from '../i18n';
 import { LOCALE, fmtDay, pickText } from '../locale';
-import type { AgentReply, ChatItem, SiteConfig } from '../types';
+import type {
+  AgentReply,
+  ChatItem,
+  SiteConfig,
+  TranscriptEntry,
+} from '../types';
 import StreamingText from './StreamingText';
 import ConfirmCard from './widgets/ConfirmCard';
 import DateTimeWidget from './widgets/DateTimeWidget';
@@ -36,6 +41,33 @@ const FALLBACK_CONFIG: SiteConfig = {
 
 const CONFIG_FETCH_ATTEMPTS = 3;
 
+const SESSION_KEY = 'agent-session-id';
+
+// localStorage can throw (private mode / storage disabled)
+function readSessionId(): string | null {
+  try {
+    return localStorage.getItem(SESSION_KEY);
+  } catch {
+    return null;
+  }
+}
+
+function writeSessionId(id: string): void {
+  try {
+    localStorage.setItem(SESSION_KEY, id);
+  } catch {
+    /* not persisted — the conversation still works within this tab */
+  }
+}
+
+function clearSessionId(): void {
+  try {
+    localStorage.removeItem(SESSION_KEY);
+  } catch {
+    /* ignore */
+  }
+}
+
 let nextId = 0;
 const uid = () => `item-${nextId++}`;
 
@@ -50,11 +82,67 @@ export default function ChatApp() {
   const [lang, setLang] = useState<'en' | 'ru'>(LOCALE);
   const [placeholderIdx, setPlaceholderIdx] = useState(0);
   const historyRef = useRef<unknown | null>(null);
+  const sessionRef = useRef<string | null>(readSessionId());
   const chatRef = useRef<HTMLDivElement>(null);
   const pendingRef = useRef<{ afterId: string; item: ChatItem } | null>(null);
 
   // conversation-language translator (may differ from the UI locale)
   const tl = i18n.getFixedT(lang);
+
+  // restore a previous conversation from the server-side session
+  useEffect(() => {
+    const id = sessionRef.current;
+    if (!id) return;
+    let alive = true;
+    fetchSession(id)
+      .then(({ transcript }) => {
+        if (!alive || !transcript.length) return;
+        setItems(transcript.flatMap(entryToItems));
+        setStarted(true);
+      })
+      .catch(() => {
+        // expired or unknown — start fresh
+        sessionRef.current = null;
+        clearSessionId();
+      });
+    return () => {
+      alive = false;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  function entryToItems(entry: TranscriptEntry): ChatItem[] {
+    if (entry.kind === 'user') {
+      return [{ kind: 'text', id: uid(), role: 'user', text: entry.text }];
+    }
+    const out: ChatItem[] = [
+      {
+        kind: 'text',
+        id: uid(),
+        role: 'agent',
+        text: entry.reply.message,
+        fresh: false,
+      },
+    ];
+    const widget = widgetFor(entry.reply);
+    if (widget) {
+      if ('resolved' in widget && entry.resolved) {
+        widget.resolved = restoredSummary(entry.reply.type, entry.resolved);
+      }
+      out.push(widget);
+    }
+    return out;
+  }
+
+  function restoredSummary(replyType: AgentReply['type'], resolved: string): string {
+    if (resolved === 'declined') return tl('summary.declined');
+    if (resolved === 'booked') return tl('summary.booked');
+    if (replyType === 'ask_datetime') {
+      const d = dayjs(resolved);
+      return `${fmtDay(d, lang)} · ${d.format('HH:mm')}`;
+    }
+    return resolved; // the confirmed email
+  }
 
   useEffect(() => {
     let alive = true;
@@ -138,8 +226,17 @@ export default function ChatApp() {
     }
     setBusy(true);
     try {
-      const { reply, history } = await sendChat(text, historyRef.current, LOCALE);
+      const { reply, history, session_id } = await sendChat(
+        text,
+        historyRef.current,
+        LOCALE,
+        sessionRef.current,
+      );
       historyRef.current = history;
+      if (session_id && session_id !== sessionRef.current) {
+        sessionRef.current = session_id;
+        writeSessionId(session_id);
+      }
       const textItem: ChatItem = {
         kind: 'text',
         id: uid(),
@@ -380,7 +477,7 @@ export default function ChatApp() {
               <p className="hero-intro">{greeting}</p>
             </div>
           ) : (
-            <div className="hero">
+            <div className="hero hero-loading">
               <div className="skel skel-avatar" />
               <div className="skel skel-title" />
               <div className="skel skel-sub" />
@@ -395,10 +492,17 @@ export default function ChatApp() {
                 className="thread-avatar"
                 style={{ backgroundImage: `url("${avatarUrl}")` }}
               />
-              <div className="thread-intro-info">
-                <div className="thread-intro-title">{title}</div>
-                <div className="thread-intro-sub">{subtitle}</div>
-              </div>
+              {config ? (
+                <div className="thread-intro-info">
+                  <div className="thread-intro-title">{title}</div>
+                  <div className="thread-intro-sub">{subtitle}</div>
+                </div>
+              ) : (
+                <div className="thread-intro-info">
+                  <span className="skel skel-title-sm" />
+                  <span className="skel skel-sub-sm" />
+                </div>
+              )}
             </div>
             {items.map(renderItem)}
             {busy && <TypingIndicator lang={lang} />}

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -814,6 +814,25 @@ textarea::placeholder {
 }
 
 /* ---------- loading skeleton (before the admin config arrives) ---------- */
+/* the entrance animation plays only when the real content lands: the
+   skeleton renders statically, and dropping this class restarts heroIn */
+.hero.hero-loading {
+  animation: none;
+}
+
+.chip {
+  animation: chipIn 0.3s ease;
+}
+
+@keyframes chipIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
 .skel {
   background: linear-gradient(
     90deg,
@@ -870,4 +889,14 @@ textarea::placeholder {
   width: 108px;
   height: 31px;
   border-radius: 999px;
+}
+
+.skel-title-sm {
+  width: 150px;
+  height: 18px;
+}
+
+.skel-sub-sm {
+  width: 180px;
+  height: 11px;
 }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -26,6 +26,16 @@ export type AgentReply =
 export interface ChatResponse {
   reply: AgentReply;
   history: unknown;
+  session_id?: string | null;
+}
+
+export type TranscriptEntry =
+  | { kind: 'user'; text: string }
+  | { kind: 'agent'; reply: AgentReply; resolved?: string | null };
+
+export interface SessionResponse {
+  session_id: string;
+  transcript: TranscriptEntry[];
 }
 
 export interface ButtonCfg {


### PR DESCRIPTION
## Sessions
- Visitors now get a server-side session: pydantic-ai history + a UI transcript stored as JSON files next to the admin config (on Railway — the **/data volume**, `/data/sessions/`). 
- `POST /api/chat` accepts and returns `session_id`; server-held history takes precedence over the client copy, so a returning visitor continues the same conversation with full agent context.
- `GET /api/session/{id}` returns the transcript for UI restore: user bubbles, agent texts, widgets (resolved ones render as summary chips — `[widget]` answers mark entries resolved server-side), success card.
- The id lives in `localStorage`; expired/unknown ids fall back to a fresh start.
- **Idle sessions are dropped after 7 days** (`SESSION_TTL_DAYS`), swept by a throttled cleanup on traffic; corrupt files are removed too.

## First-load animation jank
- The hero slide-in used to play while the skeleton was still up, so the real texts/avatar popped in mid-animation. Now the skeleton renders statically and `heroIn` starts exactly when the config content lands.
- `/my-avatar.webp` is preloaded (no photo pop), chips fade in, and the thread intro shows skeleton bars instead of fallback texts while restoring.

## Tests / verification
18/18 backend tests (new: server-side context without client history + transcript shape, widget resolution parsing, 7-day expiry + sweep). Preview-verified against the real backend: seeded session restores the full conversation (summary chips in visitor's locale/timezone, success card), `session_id` round-trips on send, fresh load animates once with zero console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)