### PR TITLE
fix: align chips with composer, pin composer to bottom on mobile

### DIFF
--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -706,17 +706,18 @@ textarea::placeholder {
   z-index: 5;
 }
 
-/* floats above the composer over the transcript — takes no layout space */
+/* floats above the composer over the transcript — takes no layout space;
+   width matches the composer exactly (zone has 16px side paddings) */
 .chips-row {
   position: absolute;
   bottom: 100%;
   left: 50%;
   transform: translateX(-50%);
-  width: min(720px, 100%);
+  width: min(720px, calc(100% - 32px));
   display: flex;
   flex-wrap: nowrap;
   gap: 7px;
-  padding: 0 4px 2px;
+  padding: 0 0 2px;
   overflow-x: auto;
   scrollbar-width: none;
   -webkit-overflow-scrolling: touch;
@@ -811,6 +812,13 @@ textarea::placeholder {
 
 .spacer.chatting {
   height: 14px;
+}
+
+/* on phones the composer hugs the bottom even on the hero screen */
+@media (max-width: 640px) {
+  .spacer {
+    height: 14px;
+  }
 }
 
 /* ---------- loading skeleton (before the admin config arrives) ---------- */


### PR DESCRIPTION
- The floating chips row was sized to the full zone width, so on phones it ran edge-to-edge and stuck out past the composer. It now matches the composer width exactly — flush on both desktop (720px centered) and mobile (16px insets).
- On phones (≤640px) the hero-screen spacer collapses to 14px, so the composer hugs the bottom of the screen instead of floating mid-page.

Verified in preview: mobile 375px — chips 16→359 = composer 16→359, composer 14px from the bottom; desktop 1280px — chips 280→1000 = composer 280→1000, hero spacing (16dvh) preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)