### PR TITLE
feat: security hardening — DDoS/abuse backstops + Turnstile plumbing

### DIFF
--- a/backend/app/agent.py
+++ b/backend/app/agent.py
@@ -12,6 +12,7 @@ from pydantic_ai.models.google import GoogleModelSettings
 from .admin_config import AgentConfig, store
 from .calendar_service import BookingResult, create_meeting, is_slot_free
 from .config import settings
+from .limits import booking_limiter
 
 logger = logging.getLogger(__name__)
 
@@ -281,11 +282,30 @@ def book_meeting(
     Call this ONLY after the visitor approved the AskConfirm recap card.
     `start` must be ISO 8601 with a UTC offset.
     """
+    if not settings.booking_enabled:
+        return (
+            "BOOKING_DISABLED: booking is temporarily turned off. Apologize "
+            "and suggest the visitor try again later or reach out directly."
+        )
+
     visitor_email = visitor_email.strip()
     if not EMAIL_RE.match(visitor_email):
         raise ModelRetry(
             "That email address is invalid. Ask the visitor for a valid one "
             "using the AskEmail widget."
+        )
+
+    # Abuse backstop: hard ceilings on bookings, independent of the LLM.
+    limit_hit = booking_limiter.check(visitor_email)
+    if limit_hit == "PER_EMAIL_LIMIT":
+        return (
+            "PER_EMAIL_LIMIT: this email already has the maximum number of "
+            "upcoming meetings. Apologize and suggest reaching out directly."
+        )
+    if limit_hit == "GLOBAL_DAILY_LIMIT":
+        return (
+            "GLOBAL_LIMIT: the daily booking limit has been reached. "
+            "Apologize and ask the visitor to try again tomorrow."
         )
 
     if start.tzinfo is None:
@@ -316,6 +336,7 @@ def book_meeting(
         )
 
     booking = create_meeting(visitor_email, start, duration_minutes, topic)
+    booking_limiter.record(visitor_email)
     ctx.deps.booking = booking
     logger.info("Meeting booked for %s at %s", visitor_email, start.isoformat())
     return (

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -34,13 +34,43 @@ class Settings(BaseSettings):
         "https://vsezol.github.io,http://localhost:5173"
     )
 
+    # Coarse per-IP anti-flood over all /api/ paths.
     rate_limit_requests: int = 30
-    rate_limit_window_seconds: int = 300
+    rate_limit_window_seconds: int = 60
     max_history_messages: int = 120
-    # Hard cap of visitor messages per conversation (token protection)
-    max_user_messages: int = 20
+    # Chat messages allowed per IP per hour (unlimited per conversation, but
+    # capped hourly so a spammer can't burn tokens). On exceed the visitor is
+    # told the limit resets within an hour — no LLM call is made.
+    messages_per_hour: int = 20
     # Sessions idle longer than this are dropped
     session_ttl_days: int = 7
+
+    # --- Abuse backstops (work even before Cloudflare is in front) ---
+    # Global circuit breaker: max agent.run calls across all visitors per
+    # hour. Over this the API replies "temporarily unavailable" WITHOUT
+    # calling the LLM — a hard ceiling on token spend.
+    global_llm_calls_per_hour: int = 500
+    # Global cap on real bookings per day (calendar-flood protection).
+    global_bookings_per_day: int = 20
+    # Max upcoming meetings a single visitor email may hold.
+    bookings_per_email: int = 2
+
+    # Instant kill switches (flip in Railway env, no redeploy needed).
+    chat_enabled: bool = True
+    booking_enabled: bool = True
+
+    # Cloudflare Turnstile secret — proves the request came from a real
+    # browser. Empty = verification disabled (no-op until CF is set up).
+    turnstile_secret: str = ""
+    # Shared secret Cloudflare injects as a header; when set, the backend
+    # rejects any request without it (blocks direct hits to the raw Railway
+    # domain that bypass Cloudflare). Empty = disabled.
+    edge_secret: str = ""
+    edge_secret_header: str = "x-edge-secret"
+
+    # Optional Telegram alerting on abuse spikes (empty = disabled).
+    telegram_bot_token: str = ""
+    telegram_chat_id: str = ""
 
     # Admin API auth (HTTP Basic; the admin UI lives in the site SPA at /#admin)
     admin_user: str = "admin"

--- a/backend/app/limits.py
+++ b/backend/app/limits.py
@@ -1,0 +1,89 @@
+"""In-process abuse backstops: LLM circuit breaker and booking caps.
+
+These are global ceilings that hold even if per-IP limits are evaded (e.g.
+rotating IPs), so an attacker can never burn more than a fixed amount of
+tokens or flood the calendar. Counters live in process memory — on a single
+Railway instance that's exact; if scaled to N instances each keeps its own
+window, so set limits with that in mind.
+"""
+
+import threading
+import time
+from collections import defaultdict, deque
+
+from .config import settings
+
+HOUR = 3600.0
+DAY = 86400.0
+
+
+class SlidingCounter:
+    """Counts events in a rolling window; `allow` checks, `record` commits."""
+
+    def __init__(self, limit: int, window_seconds: float) -> None:
+        self.limit = limit
+        self.window = window_seconds
+        self._hits: deque[float] = deque()
+        self._lock = threading.Lock()
+
+    def _trim(self, now: float) -> None:
+        while self._hits and now - self._hits[0] > self.window:
+            self._hits.popleft()
+
+    def allow(self) -> bool:
+        with self._lock:
+            now = time.monotonic()
+            self._trim(now)
+            return len(self._hits) < self.limit
+
+    def record(self) -> None:
+        with self._lock:
+            now = time.monotonic()
+            self._trim(now)
+            self._hits.append(now)
+
+    def count(self) -> int:
+        with self._lock:
+            self._trim(time.monotonic())
+            return len(self._hits)
+
+
+class BookingLimiter:
+    """Global-per-day and per-email booking ceilings."""
+
+    def __init__(self, per_day: int, per_email: int) -> None:
+        self.per_day = per_day
+        self.per_email = per_email
+        self._global: deque[float] = deque()
+        self._by_email: dict[str, deque[float]] = defaultdict(deque)
+        self._lock = threading.Lock()
+
+    def _trim(self, hits: deque[float], now: float) -> None:
+        while hits and now - hits[0] > DAY:
+            hits.popleft()
+
+    def check(self, email: str) -> str | None:
+        """Return a reason string if booking is not allowed, else None."""
+        with self._lock:
+            now = time.monotonic()
+            self._trim(self._global, now)
+            if len(self._global) >= self.per_day:
+                return "GLOBAL_DAILY_LIMIT"
+            hits = self._by_email[email.lower()]
+            self._trim(hits, now)
+            if len(hits) >= self.per_email:
+                return "PER_EMAIL_LIMIT"
+            return None
+
+    def record(self, email: str) -> None:
+        with self._lock:
+            now = time.monotonic()
+            self._global.append(now)
+            self._by_email[email.lower()].append(now)
+
+
+# Shared singletons. Global ceilings that hold across all visitors.
+llm_breaker = SlidingCounter(settings.global_llm_calls_per_hour, HOUR)
+booking_limiter = BookingLimiter(
+    settings.global_bookings_per_day, settings.bookings_per_email
+)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -7,11 +7,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from pydantic import ValidationError
 from pydantic_ai.exceptions import ModelHTTPError
-from pydantic_ai.messages import (
-    ModelMessagesTypeAdapter,
-    ModelRequest,
-    UserPromptPart,
-)
+from pydantic_ai.messages import ModelMessagesTypeAdapter
 from pydantic_ai.usage import UsageLimits
 
 from .admin import router as admin_router
@@ -25,7 +21,9 @@ from .agent import (
     strip_widget_echo,
 )
 from .config import settings
+from .limits import llm_breaker
 from .rate_limit import RateLimiter
+from .security import client_ip, edge_secret_ok, turnstile_ok
 from .sessions import session_store
 from .schemas import (
     AskConfirmReply,
@@ -52,25 +50,40 @@ app.add_middleware(
 
 app.include_router(admin_router)
 
+# Coarse per-IP anti-flood over all /api/ paths.
 rate_limiter = RateLimiter(
     settings.rate_limit_requests, settings.rate_limit_window_seconds
 )
+# Chat messages per IP per hour (the visible "20/hour" cap).
+chat_hourly = RateLimiter(settings.messages_per_hour, 3600)
 
-LIMIT_REACHED_MESSAGE = (
-    "This conversation has reached its message limit — please refresh the "
-    "page to start a new one. 🙏\n\n"
-    "Лимит сообщений для этой беседы исчерпан — обновите страницу, чтобы "
-    "начать новую. 🙏"
+HOURLY_LIMIT_MESSAGE = (
+    "You've hit the hourly message limit — it resets within an hour. "
+    "Thanks for your patience! 🙏\n\n"
+    "Вы достигли часового лимита сообщений — он восстановится в течение "
+    "часа. Спасибо за терпение! 🙏"
+)
+
+BUSY_MESSAGE = (
+    "The agent is handling a lot of requests right now — please try again "
+    "in a few minutes. 🙏\n\n"
+    "Агент сейчас перегружен запросами — попробуйте, пожалуйста, через "
+    "несколько минут. 🙏"
+)
+
+DISABLED_MESSAGE = (
+    "The chat is temporarily unavailable. Please check back soon. 🙏\n\n"
+    "Чат временно недоступен. Загляните чуть позже. 🙏"
 )
 
 
 @app.middleware("http")
-async def rate_limit_middleware(request: Request, call_next):
+async def edge_and_flood_middleware(request: Request, call_next):
     if request.url.path.startswith("/api/"):
-        client_ip = request.headers.get(
-            "x-forwarded-for", request.client.host if request.client else "?"
-        ).split(",")[0].strip()
-        if not rate_limiter.allow(client_ip):
+        # reject anything that bypassed Cloudflare (once EDGE_SECRET is set)
+        if not edge_secret_ok(request):
+            return JSONResponse({"detail": "Forbidden"}, status_code=403)
+        if not rate_limiter.allow(client_ip(request)):
             return JSONResponse(
                 {"detail": "Too many requests, please slow down."},
                 status_code=429,
@@ -201,7 +214,22 @@ def _build_reply(
 
 
 @app.post("/api/chat", response_model=ChatResponse)
-async def chat(req: ChatRequest) -> ChatResponse:
+async def chat(req: ChatRequest, request: Request) -> ChatResponse:
+    if not settings.chat_enabled:
+        return ChatResponse(reply=TextReply(message=DISABLED_MESSAGE), history=[])
+
+    # Proof this came from a real browser (no-op until Turnstile is set up).
+    if not await turnstile_ok(request, req.turnstile_token):
+        raise HTTPException(status_code=403, detail="Verification required")
+
+    # 20 messages / IP / hour — no LLM call on exceed.
+    if not chat_hourly.allow(client_ip(request)):
+        return ChatResponse(
+            reply=TextReply(message=HOURLY_LIMIT_MESSAGE),
+            history=req.history or [],
+            session_id=req.session_id,
+        )
+
     history = None
     if req.history:
         if len(req.history) > settings.max_history_messages:
@@ -225,19 +253,14 @@ async def chat(req: ChatRequest) -> ChatResponse:
             logger.warning("Corrupt history in session %s, resetting", session.id)
             session.history = []
 
-    if history is not None:
-        user_turns = sum(
-            1
-            for m in history
-            if isinstance(m, ModelRequest)
-            and any(isinstance(p, UserPromptPart) for p in m.parts)
+    # Global circuit breaker: hard ceiling on LLM spend across all visitors.
+    if not llm_breaker.allow():
+        logger.warning("LLM circuit breaker tripped — refusing without a call")
+        return ChatResponse(
+            reply=TextReply(message=BUSY_MESSAGE),
+            history=req.history or [],
+            session_id=session.id,
         )
-        if user_turns >= settings.max_user_messages:
-            return ChatResponse(
-                reply=TextReply(message=LIMIT_REACHED_MESSAGE),
-                history=req.history or [],
-                session_id=session.id,
-            )
 
     deps = AgentDeps(
         client_timezone=_validate_timezone(req.client_timezone),
@@ -245,6 +268,7 @@ async def chat(req: ChatRequest) -> ChatResponse:
     )
 
     result = None
+    llm_breaker.record()
     for attempt in range(1, AGENT_RUN_ATTEMPTS + 1):
         try:
             result = await agent.run(

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -11,6 +11,8 @@ class ChatRequest(BaseModel):
     client_locale: str | None = None
     # Server-side session to resume; a new one is created when absent/expired
     session_id: str | None = Field(default=None, max_length=64)
+    # Cloudflare Turnstile token proving the request came from a real browser
+    turnstile_token: str | None = Field(default=None, max_length=4096)
 
 
 class TextReply(BaseModel):

--- a/backend/app/security.py
+++ b/backend/app/security.py
@@ -1,0 +1,63 @@
+"""Edge/browser-proof checks: Cloudflare Turnstile + edge shared secret.
+
+Both are no-ops until their env vars are set, so the app can be deployed
+before Cloudflare is wired up and switched on afterwards without a redeploy.
+"""
+
+import logging
+
+import httpx
+from fastapi import Request
+
+from .config import settings
+
+logger = logging.getLogger(__name__)
+
+TURNSTILE_VERIFY_URL = "https://challenges.cloudflare.com/turnstile/v0/siteverify"
+TURNSTILE_HEADER = "cf-turnstile-response"
+
+
+def edge_secret_ok(request: Request) -> bool:
+    """True unless an edge secret is configured and the header doesn't match.
+
+    When `EDGE_SECRET` is set, Cloudflare injects it as a header on every
+    proxied request; a request without it reached Railway directly, bypassing
+    Cloudflare — reject it.
+    """
+    if not settings.edge_secret:
+        return True
+    got = request.headers.get(settings.edge_secret_header, "")
+    return got == settings.edge_secret
+
+
+async def turnstile_ok(request: Request, token: str | None) -> bool:
+    """Verify a Cloudflare Turnstile token. No-op if no secret configured."""
+    if not settings.turnstile_secret:
+        return True
+    if not token:
+        return False
+    data = {"secret": settings.turnstile_secret, "response": token}
+    client_ip = request.headers.get("cf-connecting-ip")
+    if client_ip:
+        data["remoteip"] = client_ip
+    try:
+        async with httpx.AsyncClient(timeout=5.0) as client:
+            resp = await client.post(TURNSTILE_VERIFY_URL, data=data)
+        return bool(resp.json().get("success"))
+    except Exception:
+        # Don't take the whole site down if Cloudflare's verify endpoint is
+        # briefly unreachable — log and allow this one through.
+        logger.warning("Turnstile verify unreachable; allowing request", exc_info=True)
+        return True
+
+
+def client_ip(request: Request) -> str:
+    """Real client IP: prefer Cloudflare's header, which (once non-CF traffic
+    is rejected) cannot be spoofed, unlike the client-settable XFF."""
+    cf = request.headers.get("cf-connecting-ip")
+    if cf:
+        return cf.strip()
+    xff = request.headers.get("x-forwarded-for", "")
+    if xff:
+        return xff.split(",")[0].strip()
+    return request.client.host if request.client else "?"

--- a/backend/scripts/cleanup_spam_events.py
+++ b/backend/scripts/cleanup_spam_events.py
@@ -1,0 +1,93 @@
+"""Delete spam meetings created by the AI agent (incident cleanup).
+
+Only touches events the agent itself created — matched by the unique marker
+in their description — so hand-made calendar events are never removed. Dry
+run by default; pass --yes to actually delete. Cancellations are NOT emailed
+(the attacker used throwaway addresses; no point spamming them).
+
+Usage (from backend/, with the same env as the app — GOOGLE_CLIENT_ID,
+GOOGLE_CLIENT_SECRET, GOOGLE_REFRESH_TOKEN):
+
+    uv run python scripts/cleanup_spam_events.py                 # preview
+    uv run python scripts/cleanup_spam_events.py --yes           # delete
+    uv run python scripts/cleanup_spam_events.py --from 2026-07-07 --to 2026-08-01 --yes
+"""
+
+import argparse
+import sys
+from datetime import datetime, timedelta, timezone
+
+from googleapiclient.errors import HttpError
+
+from app.calendar_service import _calendar_service
+
+# Unique marker written into every agent-created event's description.
+AGENT_MARKER = "Meeting booked via the AI agent"
+
+
+def _parse_date(value: str) -> datetime:
+    return datetime.strptime(value, "%Y-%m-%d").replace(tzinfo=timezone.utc)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--from", dest="frm", help="YYYY-MM-DD (default: now)")
+    parser.add_argument("--to", dest="to", help="YYYY-MM-DD (default: +90 days)")
+    parser.add_argument(
+        "--yes", action="store_true", help="actually delete (default: dry run)"
+    )
+    args = parser.parse_args()
+
+    time_min = _parse_date(args.frm) if args.frm else datetime.now(timezone.utc)
+    time_max = _parse_date(args.to) if args.to else time_min + timedelta(days=90)
+
+    service = _calendar_service()
+    print(f"Scanning primary calendar {time_min.date()} … {time_max.date()}")
+
+    matched, deleted, page_token = [], 0, None
+    while True:
+        resp = (
+            service.events()
+            .list(
+                calendarId="primary",
+                timeMin=time_min.isoformat(),
+                timeMax=time_max.isoformat(),
+                singleEvents=True,
+                showDeleted=False,
+                maxResults=250,
+                pageToken=page_token,
+            )
+            .execute()
+        )
+        for ev in resp.get("items", []):
+            if AGENT_MARKER not in (ev.get("description") or ""):
+                continue
+            matched.append(ev)
+        page_token = resp.get("nextPageToken")
+        if not page_token:
+            break
+
+    print(f"Found {len(matched)} agent-created event(s).")
+    for ev in matched:
+        when = ev.get("start", {}).get("dateTime", "?")
+        print(f"  {when}  {ev.get('summary', '(no title)')}  [{ev.get('id')}]")
+
+    if not args.yes:
+        print("\nDry run — nothing deleted. Re-run with --yes to remove these.")
+        return 0
+
+    print(f"\nDeleting {len(matched)} event(s)…")
+    for ev in matched:
+        try:
+            service.events().delete(
+                calendarId="primary", eventId=ev["id"], sendUpdates="none"
+            ).execute()
+            deleted += 1
+        except HttpError as exc:
+            print(f"  failed to delete {ev.get('id')}: {exc}")
+    print(f"Done. Deleted {deleted}/{len(matched)}.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -7,6 +7,13 @@ os.environ["ADMIN_PASSWORD"] = "test-admin-pass"
 os.environ["CONFIG_PATH"] = os.path.join(
     tempfile.mkdtemp(prefix="agent-test-"), "agent_config.json"
 )
+# Keep the shared in-process limiters out of the way of the suite; each
+# limit is exercised in its own test by swapping in a small limiter.
+os.environ["RATE_LIMIT_REQUESTS"] = "100000"
+os.environ["MESSAGES_PER_HOUR"] = "100000"
+os.environ["GLOBAL_LLM_CALLS_PER_HOUR"] = "100000"
+os.environ["GLOBAL_BOOKINGS_PER_DAY"] = "100000"
+os.environ["BOOKINGS_PER_EMAIL"] = "100000"
 
 from datetime import datetime, timedelta, timezone
 
@@ -17,6 +24,37 @@ from pydantic_ai.models.function import FunctionModel
 
 def _text_model(text: str) -> FunctionModel:
     return FunctionModel(lambda messages, info: ModelResponse(parts=[TextPart(text)]))
+
+
+def _book_then_speak():
+    """Scripted model: first turn calls book_meeting, then speaks the result."""
+    from zoneinfo import ZoneInfo
+
+    start = datetime.now(ZoneInfo("Europe/Moscow")).replace(
+        hour=12, minute=0, second=0, microsecond=0
+    ) + timedelta(days=1)
+    while start.weekday() > 4:
+        start += timedelta(days=1)
+    state = {"calls": 0}
+
+    def model(messages, info):
+        state["calls"] += 1
+        if state["calls"] == 1:
+            return ModelResponse(
+                parts=[
+                    ToolCallPart(
+                        "book_meeting",
+                        {
+                            "visitor_email": "visitor@example.com",
+                            "start": start.isoformat(),
+                            "duration_minutes": 30,
+                        },
+                    )
+                ]
+            )
+        return ModelResponse(parts=[TextPart("All set!")])
+
+    return model
 
 from app.agent import AgentDeps, AskConfirm, AskDateTime, AskEmail
 from app.agent import agent as booking_agent
@@ -306,24 +344,141 @@ def test_non_transient_error_fails_fast():
     assert calls["n"] == 1
 
 
-def test_message_limit():
-    from pydantic_ai.messages import (
-        ModelMessagesTypeAdapter,
-        ModelRequest,
-        UserPromptPart,
-    )
+def test_hourly_message_limit():
+    import app.main as main_mod
+    from app.rate_limit import RateLimiter
 
-    history = ModelMessagesTypeAdapter.dump_python(
-        [ModelRequest(parts=[UserPromptPart(content=f"msg {i}")]) for i in range(20)],
-        mode="json",
-    )
-    r = client.post(
-        "/api/chat",
-        json={"message": "one more", "history": history, "client_timezone": "UTC"},
-    )
-    assert r.status_code == 200
-    assert r.json()["reply"]["type"] == "text"
-    assert "limit" in r.json()["reply"]["message"].lower()
+    original = main_mod.chat_hourly
+    main_mod.chat_hourly = RateLimiter(1, 3600)
+    try:
+        with booking_agent.override(model=_text_model("hi")):
+            headers = {"cf-connecting-ip": "203.0.113.7"}
+            r1 = client.post(
+                "/api/chat",
+                json={"message": "one", "client_timezone": "UTC"},
+                headers=headers,
+            )
+            assert r1.status_code == 200
+            r2 = client.post(
+                "/api/chat",
+                json={"message": "two", "client_timezone": "UTC"},
+                headers=headers,
+            )
+            assert r2.status_code == 200
+            assert "час" in r2.json()["reply"]["message"]  # hourly reset text
+
+            # a different IP is not throttled
+            r3 = client.post(
+                "/api/chat",
+                json={"message": "three", "client_timezone": "UTC"},
+                headers={"cf-connecting-ip": "203.0.113.8"},
+            )
+            assert "час" not in r3.json()["reply"]["message"]
+    finally:
+        main_mod.chat_hourly = original
+
+
+def test_llm_circuit_breaker():
+    import app.main as main_mod
+    from app.limits import SlidingCounter
+
+    original = main_mod.llm_breaker
+    main_mod.llm_breaker = SlidingCounter(0, 3600)  # allow() always False
+    try:
+        called = {"n": 0}
+
+        def model(messages, info):
+            called["n"] += 1
+            return ModelResponse(parts=[TextPart("should not run")])
+
+        with booking_agent.override(model=FunctionModel(model)):
+            r = client.post(
+                "/api/chat",
+                json={"message": "hi", "client_timezone": "UTC"},
+                headers={"cf-connecting-ip": "203.0.113.9"},
+            )
+        assert r.status_code == 200
+        assert "перегружен" in r.json()["reply"]["message"]
+        assert called["n"] == 0  # LLM never invoked
+    finally:
+        main_mod.llm_breaker = original
+
+
+def test_chat_kill_switch():
+    from app.config import settings
+
+    settings.chat_enabled = False
+    try:
+        r = client.post("/api/chat", json={"message": "hi", "client_timezone": "UTC"})
+        assert r.status_code == 200
+        assert "недоступен" in r.json()["reply"]["message"]
+    finally:
+        settings.chat_enabled = True
+
+
+def test_edge_secret_rejects_non_cloudflare():
+    from app.config import settings
+
+    settings.edge_secret = "s3cr3t"
+    try:
+        r = client.post("/api/chat", json={"message": "hi", "client_timezone": "UTC"})
+        assert r.status_code == 403
+        with booking_agent.override(model=_text_model("ok")):
+            r2 = client.post(
+                "/api/chat",
+                json={"message": "hi", "client_timezone": "UTC"},
+                headers={settings.edge_secret_header: "s3cr3t"},
+            )
+        assert r2.status_code == 200
+    finally:
+        settings.edge_secret = ""
+
+
+def test_turnstile_required_when_configured():
+    from app.config import settings
+
+    settings.turnstile_secret = "ts-secret"
+    try:
+        r = client.post("/api/chat", json={"message": "hi", "client_timezone": "UTC"})
+        assert r.status_code == 403  # no token supplied
+    finally:
+        settings.turnstile_secret = ""
+
+
+def test_booking_kill_switch_blocks_booking():
+    from app.config import settings
+
+    settings.booking_enabled = False
+    try:
+        with booking_agent.override(model=FunctionModel(_book_then_speak())):
+            r = client.post(
+                "/api/chat",
+                json={"message": "[widget] Confirmed", "client_timezone": "UTC"},
+                headers={"cf-connecting-ip": "203.0.113.20"},
+            )
+        assert r.status_code == 200
+        assert r.json()["reply"]["type"] != "booked"
+    finally:
+        settings.booking_enabled = True
+
+
+def test_global_booking_cap():
+    from app.limits import BookingLimiter
+
+    lim = BookingLimiter(per_day=1, per_email=99)
+    assert lim.check("a@b.co") is None
+    lim.record("a@b.co")
+    assert lim.check("c@d.co") == "GLOBAL_DAILY_LIMIT"
+
+
+def test_per_email_booking_cap():
+    from app.limits import BookingLimiter
+
+    lim = BookingLimiter(per_day=99, per_email=1)
+    assert lim.check("a@b.co") is None
+    lim.record("a@b.co")
+    assert lim.check("a@b.co") == "PER_EMAIL_LIMIT"
+    assert lim.check("other@b.co") is None  # per-email, not global
 
 
 def test_public_config():

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,3 +1,4 @@
+import { getTurnstileToken } from './turnstile';
 import type { ChatResponse, SessionResponse, SiteConfig } from './types';
 
 const API_URL: string = import.meta.env.VITE_API_URL ?? '';
@@ -11,6 +12,7 @@ export async function sendChat(
   locale: string,
   sessionId: string | null,
 ): Promise<ChatResponse> {
+  const turnstileToken = await getTurnstileToken();
   const post = () =>
     fetch(`${API_URL}/api/chat`, {
       method: 'POST',
@@ -21,6 +23,7 @@ export async function sendChat(
         client_timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
         client_locale: locale,
         session_id: sessionId,
+        turnstile_token: turnstileToken,
       }),
     });
 

--- a/frontend/src/turnstile.ts
+++ b/frontend/src/turnstile.ts
@@ -1,0 +1,79 @@
+// Cloudflare Turnstile token provider — proves the request came from a real
+// browser. Entirely inert until VITE_TURNSTILE_SITE_KEY is set, so shipping
+// it has zero effect on visitors until Cloudflare is wired up.
+
+const SITE_KEY = import.meta.env.VITE_TURNSTILE_SITE_KEY as string | undefined;
+const SCRIPT_URL =
+  'https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit';
+
+interface Turnstile {
+  render: (el: HTMLElement, opts: Record<string, unknown>) => string;
+  execute: (id: string) => void;
+  reset: (id: string) => void;
+}
+declare global {
+  interface Window {
+    turnstile?: Turnstile;
+  }
+}
+
+let scriptPromise: Promise<void> | null = null;
+let widgetId: string | null = null;
+let pending: ((token: string | null) => void) | null = null;
+
+function loadScript(): Promise<void> {
+  if (scriptPromise) return scriptPromise;
+  scriptPromise = new Promise<void>((resolve, reject) => {
+    const s = document.createElement('script');
+    s.src = SCRIPT_URL;
+    s.async = true;
+    s.defer = true;
+    s.onload = () => resolve();
+    s.onerror = () => reject(new Error('Turnstile failed to load'));
+    document.head.appendChild(s);
+  });
+  return scriptPromise;
+}
+
+async function ensureWidget(): Promise<void> {
+  await loadScript();
+  if (widgetId != null || !window.turnstile) return;
+  const holder = document.createElement('div');
+  holder.style.display = 'none';
+  document.body.appendChild(holder);
+  widgetId = window.turnstile.render(holder, {
+    sitekey: SITE_KEY,
+    execution: 'execute', // token minted on demand via execute()
+    callback: (token: string) => {
+      pending?.(token);
+      pending = null;
+    },
+    'error-callback': () => {
+      pending?.(null);
+      pending = null;
+    },
+  });
+}
+
+/** A fresh single-use token, or null if Turnstile isn't configured/available. */
+export async function getTurnstileToken(): Promise<string | null> {
+  if (!SITE_KEY) return null;
+  try {
+    await ensureWidget();
+    if (!window.turnstile || widgetId == null) return null;
+    return await new Promise<string | null>((resolve) => {
+      pending = resolve;
+      window.turnstile!.reset(widgetId!);
+      window.turnstile!.execute(widgetId!);
+      // don't hang the send if the challenge never resolves
+      window.setTimeout(() => {
+        if (pending === resolve) {
+          pending = null;
+          resolve(null);
+        }
+      }, 8000);
+    });
+  } catch {
+    return null;
+  }
+}

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -2,6 +2,7 @@
 
 interface ImportMetaEnv {
   readonly VITE_API_URL?: string;
+  readonly VITE_TURNSTILE_SITE_KEY?: string;
 }
 
 interface ImportMeta {


### PR DESCRIPTION
## Context
Response to an automated attack (script attached in the report) that drove the full booking flow via crafted `[widget]` messages against the unauthenticated `/api/chat`, spamming the calendar and burning Gemini tokens. Per the owner's call: **no OTP** (kills conversion), keep it friction-free, Cloudflare yes.

## Backstops that work the moment this deploys (no Cloudflare needed)
- **Global LLM circuit breaker** — hard ceiling on `agent.run` calls/hour across all visitors; over it the API replies 'busy' *without calling Gemini*. Token spend can't run away.
- **Booking caps** — global bookings/day + per-email upcoming cap enforced in `book_meeting`. Calendar can't be flooded.
- **Kill switches** — `BOOKING_ENABLED` / `CHAT_ENABLED` env flags, instant off without redeploy.
- **20 messages / IP / hour** — unlimited per conversation, but hourly-capped; friendly 'resets within an hour' message, no LLM call on exceed. Replaces the per-session 20-cap the attack trivially bypassed by rotating sessions.

## Edge / anti-bot (inert until keys are set — enable after Cloudflare)
- **Turnstile** verification on `/api/chat` (backend siteverify + frontend token provider). A `requests`-based script can't mint a token → dies at the first call. Zero friction for real browsers.
- **EDGE_SECRET** header check — rejects requests that bypass Cloudflare and hit the raw Railway domain directly (exactly how the attack ran).
- Rate-limit now keys on **CF-Connecting-IP**, not the spoofable `X-Forwarded-For`.

## Ops
- `backend/scripts/cleanup_spam_events.py` — deletes agent-created spam meetings by their unique description marker. Dry-run by default; sends no cancellation emails to the throwaway addresses.

## Tests
25 backend tests pass — new coverage: hourly limit (+ per-IP isolation), circuit breaker (LLM never called), both kill switches, edge-secret reject, turnstile-required, global & per-email booking caps. Frontend build green; preview-verified the current-user path is unchanged and Turnstile stays dormant without a site key.

## Not in this PR (tracked follow-ups)
- Cloudflare account wiring (subdomain proxy, Turnstile keys, WAF/rate rules, lock Railway) — infra, needs owner.
- Session-id → HttpOnly cookie (guessing is already infeasible at 128-bit; this closes the leakage vector).

🤖 Generated with [Claude Code](https://claude.com/claude-code)