### PR TITLE
ci: wire Turnstile site key into Pages build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,6 +35,10 @@ jobs:
         run: npm run build
         env:
           VITE_API_URL: ${{ vars.API_URL }}
+          # Public Cloudflare Turnstile site key (safe to expose). Set the
+          # TURNSTILE_SITE_KEY repo variable to activate the browser check;
+          # empty → Turnstile stays inert.
+          VITE_TURNSTILE_SITE_KEY: ${{ vars.TURNSTILE_SITE_KEY }}
 
       - name: Deploy to GitHub Pages
         if: github.event_name != 'pull_request'


### PR DESCRIPTION
Pre-wires `VITE_TURNSTILE_SITE_KEY` from a `TURNSTILE_SITE_KEY` repo variable so activating Turnstile is just setting the variable — no workflow edit later. Empty variable keeps it inert. Split out of #25.

🤖 Generated with [Claude Code](https://claude.com/claude-code)