### PR TITLE
fix: Turnstile interaction-only (don't silently block real users)

### DIFF
--- a/frontend/src/turnstile.ts
+++ b/frontend/src/turnstile.ts
@@ -38,12 +38,21 @@ function loadScript(): Promise<void> {
 async function ensureWidget(): Promise<void> {
   await loadScript();
   if (widgetId != null || !window.turnstile) return;
+  // Renderable container (NOT display:none) so that, on the rare occasion
+  // Cloudflare needs interaction, the challenge can actually show instead of
+  // silently failing and locking the visitor out. `interaction-only` keeps it
+  // invisible whenever no interaction is required (the common case).
   const holder = document.createElement('div');
-  holder.style.display = 'none';
+  holder.style.position = 'fixed';
+  holder.style.bottom = '16px';
+  holder.style.left = '50%';
+  holder.style.transform = 'translateX(-50%)';
+  holder.style.zIndex = '2147483647';
   document.body.appendChild(holder);
   widgetId = window.turnstile.render(holder, {
     sitekey: SITE_KEY,
     execution: 'execute', // token minted on demand via execute()
+    appearance: 'interaction-only', // only visible if a challenge is required
     callback: (token: string) => {
       pending?.(token);
       pending = null;


### PR DESCRIPTION
Follow-up to the security hardening now that the Turnstile keys are set. The token provider rendered the widget in a `display:none` holder — if Cloudflare ever needs interaction, an invisible widget can't show the challenge, the token never arrives, and (once the backend requires a token) the visitor is locked out. Switch to a renderable fixed container + `appearance: 'interaction-only'`: invisible in the common case, but able to show a challenge when genuinely required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)