### PR TITLE
fix: localized limit message + per-session hourly cap

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import re
 from zoneinfo import ZoneInfo
 
 from fastapi import FastAPI, HTTPException, Request
@@ -57,24 +58,46 @@ rate_limiter = RateLimiter(
 # Chat messages per IP per hour (the visible "20/hour" cap).
 chat_hourly = RateLimiter(settings.messages_per_hour, 3600)
 
-HOURLY_LIMIT_MESSAGE = (
-    "You've hit the hourly message limit — it resets within an hour. "
-    "Thanks for your patience! 🙏\n\n"
-    "Вы достигли часового лимита сообщений — он восстановится в течение "
-    "часа. Спасибо за терпение! 🙏"
-)
+# System messages that bypass the LLM. Kept per-language (shown in the
+# language the visitor is writing in) and without emoji.
+HOURLY_LIMIT_MESSAGE = {
+    "en": (
+        "You've hit the hourly message limit — it resets within an hour. "
+        "Thanks for your patience."
+    ),
+    "ru": (
+        "Вы достигли часового лимита сообщений — он восстановится в течение "
+        "часа. Спасибо за терпение."
+    ),
+}
 
-BUSY_MESSAGE = (
-    "The agent is handling a lot of requests right now — please try again "
-    "in a few minutes. 🙏\n\n"
-    "Агент сейчас перегружен запросами — попробуйте, пожалуйста, через "
-    "несколько минут. 🙏"
-)
+BUSY_MESSAGE = {
+    "en": (
+        "The agent is handling a lot of requests right now — please try "
+        "again in a few minutes."
+    ),
+    "ru": (
+        "Агент сейчас перегружен запросами — попробуйте, пожалуйста, через "
+        "несколько минут."
+    ),
+}
 
-DISABLED_MESSAGE = (
-    "The chat is temporarily unavailable. Please check back soon. 🙏\n\n"
-    "Чат временно недоступен. Загляните чуть позже. 🙏"
-)
+DISABLED_MESSAGE = {
+    "en": "The chat is temporarily unavailable. Please check back soon.",
+    "ru": "Чат временно недоступен. Загляните чуть позже.",
+}
+
+_CYRILLIC = re.compile(r"[а-яё]", re.IGNORECASE)
+
+
+def _lang(message: str, client_locale: str | None) -> str:
+    """Language for system messages: what the visitor is writing in, falling
+    back to their browser locale."""
+    if _CYRILLIC.search(message or ""):
+        return "ru"
+    if (client_locale or "").lower().startswith("ru"):
+        return "ru"
+    return "en"
 
 
 @app.middleware("http")
@@ -215,17 +238,23 @@ def _build_reply(
 
 @app.post("/api/chat", response_model=ChatResponse)
 async def chat(req: ChatRequest, request: Request) -> ChatResponse:
+    lang = _lang(req.message, req.client_locale)
+
     if not settings.chat_enabled:
-        return ChatResponse(reply=TextReply(message=DISABLED_MESSAGE), history=[])
+        return ChatResponse(reply=TextReply(message=DISABLED_MESSAGE[lang]), history=[])
 
     # Proof this came from a real browser (no-op until Turnstile is set up).
     if not await turnstile_ok(request, req.turnstile_token):
         raise HTTPException(status_code=403, detail="Verification required")
 
-    # 20 messages / IP / hour — no LLM call on exceed.
-    if not chat_hourly.allow(client_ip(request)):
+    # Hourly cap on *typed* messages, keyed per conversation (session) — not
+    # per IP, so visitors sharing a carrier/CGNAT address don't drain each
+    # other's budget. Widget events ([widget] ...) are one user action mid-
+    # booking, so they don't count. No LLM call on exceed.
+    rate_key = req.session_id or client_ip(request)
+    if not req.message.startswith("[widget]") and not chat_hourly.allow(rate_key):
         return ChatResponse(
-            reply=TextReply(message=HOURLY_LIMIT_MESSAGE),
+            reply=TextReply(message=HOURLY_LIMIT_MESSAGE[lang]),
             history=req.history or [],
             session_id=req.session_id,
         )
@@ -257,7 +286,7 @@ async def chat(req: ChatRequest, request: Request) -> ChatResponse:
     if not llm_breaker.allow():
         logger.warning("LLM circuit breaker tripped — refusing without a call")
         return ChatResponse(
-            reply=TextReply(message=BUSY_MESSAGE),
+            reply=TextReply(message=BUSY_MESSAGE[lang]),
             history=req.history or [],
             session_id=session.id,
         )

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -344,7 +344,7 @@ def test_non_transient_error_fails_fast():
     assert calls["n"] == 1
 
 
-def test_hourly_message_limit():
+def test_hourly_message_limit_and_localization():
     import app.main as main_mod
     from app.rate_limit import RateLimiter
 
@@ -352,20 +352,18 @@ def test_hourly_message_limit():
     main_mod.chat_hourly = RateLimiter(1, 3600)
     try:
         with booking_agent.override(model=_text_model("hi")):
-            headers = {"cf-connecting-ip": "203.0.113.7"}
+            ip = {"cf-connecting-ip": "203.0.113.7"}
             r1 = client.post(
-                "/api/chat",
-                json={"message": "one", "client_timezone": "UTC"},
-                headers=headers,
+                "/api/chat", json={"message": "one", "client_timezone": "UTC"}, headers=ip
             )
-            assert r1.status_code == 200
+            assert r1.status_code == 200 and "hourly" not in r1.json()["reply"]["message"]
+            # second (English) message over the limit → English text, no emoji
             r2 = client.post(
-                "/api/chat",
-                json={"message": "two", "client_timezone": "UTC"},
-                headers=headers,
+                "/api/chat", json={"message": "two", "client_timezone": "UTC"}, headers=ip
             )
-            assert r2.status_code == 200
-            assert "час" in r2.json()["reply"]["message"]  # hourly reset text
+            msg = r2.json()["reply"]["message"]
+            assert "hourly message limit" in msg
+            assert "🙏" not in msg and "час" not in msg
 
             # a different IP is not throttled
             r3 = client.post(
@@ -373,7 +371,55 @@ def test_hourly_message_limit():
                 json={"message": "three", "client_timezone": "UTC"},
                 headers={"cf-connecting-ip": "203.0.113.8"},
             )
-            assert "час" not in r3.json()["reply"]["message"]
+            assert "hourly message limit" not in r3.json()["reply"]["message"]
+
+            # a Russian over-limit message → Russian text
+            r4 = client.post(
+                "/api/chat", json={"message": "привет", "client_timezone": "UTC"}, headers=ip
+            )
+            rmsg = r4.json()["reply"]["message"]
+            assert "часового лимита" in rmsg and "🙏" not in rmsg
+    finally:
+        main_mod.chat_hourly = original
+
+
+def test_hourly_limit_is_per_session_not_ip():
+    """Visitors sharing a carrier/CGNAT IP must not drain each other's budget,
+    and widget events don't count."""
+    import app.main as main_mod
+    from app.rate_limit import RateLimiter
+
+    original = main_mod.chat_hourly
+    main_mod.chat_hourly = RateLimiter(1, 3600)
+    try:
+        with booking_agent.override(model=_text_model("hi")):
+            ip = {"cf-connecting-ip": "198.51.100.5"}  # same IP for everyone
+            a = client.post(
+                "/api/chat",
+                json={"message": "hi", "session_id": "a" * 32, "client_timezone": "UTC"},
+                headers=ip,
+            )
+            b = client.post(
+                "/api/chat",
+                json={"message": "hi", "session_id": "b" * 32, "client_timezone": "UTC"},
+                headers=ip,
+            )
+            # different sessions → neither throttled despite the shared IP
+            assert "hourly" not in a.json()["reply"]["message"]
+            assert "hourly" not in b.json()["reply"]["message"]
+
+            # widget events never count toward the cap
+            for _ in range(3):
+                w = client.post(
+                    "/api/chat",
+                    json={
+                        "message": "[widget] Confirmed — book the meeting.",
+                        "session_id": "a" * 32,
+                        "client_timezone": "UTC",
+                    },
+                    headers=ip,
+                )
+                assert "hourly" not in w.json()["reply"]["message"]
     finally:
         main_mod.chat_hourly = original
 
@@ -398,7 +444,8 @@ def test_llm_circuit_breaker():
                 headers={"cf-connecting-ip": "203.0.113.9"},
             )
         assert r.status_code == 200
-        assert "перегружен" in r.json()["reply"]["message"]
+        msg = r.json()["reply"]["message"]
+        assert "few minutes" in msg and "🙏" not in msg  # English, no emoji
         assert called["n"] == 0  # LLM never invoked
     finally:
         main_mod.llm_breaker = original
@@ -411,7 +458,12 @@ def test_chat_kill_switch():
     try:
         r = client.post("/api/chat", json={"message": "hi", "client_timezone": "UTC"})
         assert r.status_code == 200
-        assert "недоступен" in r.json()["reply"]["message"]
+        assert "temporarily unavailable" in r.json()["reply"]["message"]
+        # Russian visitor gets the Russian variant
+        r2 = client.post(
+            "/api/chat", json={"message": "привет", "client_timezone": "UTC"}
+        )
+        assert "недоступен" in r2.json()["reply"]["message"]
     finally:
         settings.chat_enabled = True
 


### PR DESCRIPTION
Three fixes from testing the live Turnstile rollout:

1. **Localized system messages, no emoji** — the hourly-limit / busy / chat-disabled messages replied bilingually with a 🙏. They now answer in the visitor's language only (detected from their message, falling back to browser locale) with no emoji.
2. **Hourly cap keyed per session, not per IP** — mobile visitors all share a carrier/CGNAT public IP, so a per-IP cap let strangers (and my own testing traffic on a shared home IP) drain each other's budget — that's why a phone hit the limit "though I chatted yesterday". Now each conversation has its own hourly budget.
3. **`[widget]` events don't count** — a booking's Approve/confirm clicks are one user action; counting them could exhaust the quota mid-booking.

Safe because abuse is now held by Turnstile (blocks scripts) + the global LLM circuit breaker + booking caps — the per-IP throttle was redundant. The attack script (`main.py`) was re-run and dies at the first request with 403 (no Turnstile token).

26 backend tests pass (updated + new: localization, per-session keying, widget-exempt).

🤖 Generated with [Claude Code](https://claude.com/claude-code)