### PR TITLE
fix: admin scrolls clear of the fixed save bar

### DIFF
--- a/frontend/src/admin/AdminApp.tsx
+++ b/frontend/src/admin/AdminApp.tsx
@@ -460,6 +460,10 @@ export default function AdminApp() {
 
         {creds && <SpamCleanup creds={creds} />}
 
+        {/* tail spacer so the last card clears the fixed save bar (a flex
+            scroll column ignores padding-bottom) */}
+        <div className="adm-tailspace" aria-hidden="true" />
+
         <div className="adm-savebar">
           <div className="adm-savebar-in">
             <button type="button" className="adm-save" onClick={() => void save()}>

--- a/frontend/src/styles/admin.css
+++ b/frontend/src/styles/admin.css
@@ -55,7 +55,14 @@
   display: flex;
   flex-direction: column;
   gap: 14px;
-  padding: 20px 16px 110px;
+  padding: 20px 16px 24px;
+}
+
+/* Real spacer element — a flex-column scroll area ignores padding-bottom, so
+   this is what actually lets the last card's buttons clear the fixed save bar. */
+.adm-tailspace {
+  flex: none;
+  height: 140px;
 }
 
 .adm-head {


### PR DESCRIPTION
The spam-cleanup card's Preview/Delete buttons (and any last card) were hidden behind the fixed Save bar and couldn't be scrolled into view. Root cause: a flex-column scroll area ignores `padding-bottom`, so the bottom clearance never existed. Replaced it with a real `flex:none` tail spacer element, which the scroll area honors.

Verified in preview: fully scrolled, the Preview button clears the bar by 85px, and with the list open the Delete button + all rows are visible above the bar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)